### PR TITLE
  feat: simplify responsive visibility & migrate to lucide icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A PayloadCMS plugin for integrating [Puck](https://puckeditor.com) visual page b
 |------------|---------|---------|
 | `@measured/puck` | >= 0.20.0 | Visual editor core |
 | `payload` | >= 3.0.0 | CMS backend |
-| `next` | >= 15.4.0 | React framework |
+| `next` | >= 15.4.8 | React framework |
 | `react` | >= 18.0.0 | UI library |
 | `@tailwindcss/typography` | >= 0.5.0 | RichText component styling |
 
@@ -64,8 +64,9 @@ The package includes ready-to-use example files:
 # Copy API routes
 cp -r node_modules/@delmaredigital/payload-puck/examples/api/puck src/app/api/
 
-# Copy editor page
+# Copy editor layout (REQUIRED - imports Tailwind CSS) and page
 mkdir -p src/app/\(manage\)/pages/\[id\]/edit
+cp node_modules/@delmaredigital/payload-puck/examples/app/\(manage\)/layout.tsx src/app/\(manage\)/
 cp node_modules/@delmaredigital/payload-puck/examples/app/pages/\[id\]/edit/page.tsx src/app/\(manage\)/pages/\[id\]/edit/
 
 # Copy frontend routes (homepage + dynamic pages)
@@ -78,6 +79,8 @@ cp node_modules/@delmaredigital/payload-puck/examples/app/\[...slug\]/page.tsx s
 mkdir -p src/lib
 cp node_modules/@delmaredigital/payload-puck/examples/lib/puck-theme.ts src/lib/
 ```
+
+> **Important:** Update the CSS import path in `src/app/(manage)/layout.tsx` to match your project's globals.css location.
 
 See `examples/README.md` for detailed customization instructions.
 
@@ -142,10 +145,33 @@ export const { GET, PATCH, DELETE } = createPuckApiRoutesWithId({
 })
 ```
 
-#### Step 3: Create the Editor Page
+#### Step 3: Create the Editor Layout & Page
+
+First, create a layout that imports your Tailwind CSS:
 
 ```typescript
-// app/pages/[id]/edit/page.tsx
+// app/(manage)/layout.tsx
+import '@/app/(frontend)/globals.css' // Adjust path to your CSS
+
+export const metadata = {
+  title: 'Puck Editor',
+  description: 'Visual page editor',
+}
+
+export default function ManageLayout({ children }: { children: React.ReactNode }) {
+  return (
+    // data-theme may be required if your CSS hides content until theme is set
+    <html lang="en" data-theme="light">
+      <body>{children}</body>
+    </html>
+  )
+}
+```
+
+Then create the editor page:
+
+```typescript
+// app/(manage)/pages/[id]/edit/page.tsx
 'use client'
 
 import { PuckEditorView } from '@delmaredigital/payload-puck/editor'
@@ -400,6 +426,7 @@ Use this checklist to verify your setup is complete.
 - [ ] Install packages: `@delmaredigital/payload-puck` and `@measured/puck`
 - [ ] Add `createPuckPlugin()` to your Payload config
 - [ ] Create API routes (`/api/puck/pages` and `/api/puck/pages/[id]`)
+- [ ] Create editor route layout that imports Tailwind CSS (see examples)
 - [ ] Create the editor page component with `PuckEditorView`
 - [ ] Create a frontend route with `PageRenderer`
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,6 +17,8 @@ examples/
 ├── app/
 │   ├── (frontend)/
 │   │   └── page.tsx                  # Homepage route (root "/")
+│   ├── (manage)/
+│   │   └── layout.tsx                # Editor layout (imports Tailwind CSS)
 │   ├── pages/
 │   │   └── [id]/
 │   │       └── edit/
@@ -65,13 +67,18 @@ export default buildConfig({
 cp -r node_modules/@delmaredigital/payload-puck/examples/api/puck src/app/api/
 ```
 
-### 3. Copy Editor Page
+### 3. Copy Editor Page & Layout
 
 ```bash
-# Adjust the destination path as needed for your route structure
+# Create route group and copy layout (REQUIRED for Tailwind styles)
 mkdir -p src/app/\(manage\)/pages/\[id\]/edit
+cp node_modules/@delmaredigital/payload-puck/examples/app/\(manage\)/layout.tsx src/app/\(manage\)/
+
+# Copy editor page
 cp node_modules/@delmaredigital/payload-puck/examples/app/pages/\[id\]/edit/page.tsx src/app/\(manage\)/pages/\[id\]/edit/
 ```
+
+> **Important:** The layout file imports Tailwind CSS. Without it, the editor will be completely unstyled. Update the CSS import path in `layout.tsx` to match your project's globals.css location.
 
 ### 4. Copy Frontend Routes
 

--- a/examples/app/(manage)/layout.tsx
+++ b/examples/app/(manage)/layout.tsx
@@ -1,0 +1,31 @@
+/**
+ * Layout for Puck Editor routes
+ *
+ * IMPORTANT: This layout must import your Tailwind CSS for the editor to be styled.
+ * Update the import path to match your project's globals.css location.
+ */
+
+// Import your Tailwind CSS - adjust path as needed
+import '@/app/(frontend)/globals.css'
+// Or if your globals.css is elsewhere:
+// import '@/styles/globals.css'
+// import '../globals.css'
+
+export const metadata = {
+  title: 'Puck Editor',
+  description: 'Visual page editor',
+}
+
+export default function ManageLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    // NOTE: data-theme="light" is required if your CSS uses opacity:0 until theme is set
+    // (common FOUC prevention pattern). Adjust to match your theme system.
+    <html lang="en" data-theme="light">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   "peerDependencies": {
     "@measured/puck": ">=0.20.0",
     "@payloadcms/ui": ">=3.0.0",
-    "next": ">=15.4.0",
+    "next": ">=15.4.8",
     "payload": ">=3.0.0",
     "react": ">=18.0.0"
   },
@@ -102,11 +102,12 @@
   },
   "dependencies": {
     "@measured/puck-plugin-heading-analyzer": "^0.20.2",
+    "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
-    "@tabler/icons-react": "^3.36.1",
+    "lucide-react": "^0.469.0",
     "@tiptap/core": "^3.14.0",
     "@tiptap/extension-color": "^3.14.0",
     "@tiptap/extension-highlight": "^3.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@measured/puck-plugin-heading-analyzer':
         specifier: ^0.20.2
         version: 0.20.2(react@19.2.3)
+      '@radix-ui/react-checkbox':
+        specifier: ^1.3.2
+        version: 1.3.3(@types/react-dom@18.3.7(@types/react@19.2.7))(@types/react@19.2.7)(react@19.2.3)
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@18.3.7(@types/react@19.2.7))(@types/react@19.2.7)(react@19.2.3)
@@ -23,9 +26,6 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.7)(react@19.2.3)
-      '@tabler/icons-react':
-        specifier: ^3.36.1
-        version: 3.36.1(react@19.2.3)
       '@tiptap/core':
         specifier: ^3.14.0
         version: 3.14.0(@tiptap/pm@3.14.0)
@@ -65,6 +65,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      lucide-react:
+        specifier: ^0.469.0
+        version: 0.469.0(react@19.2.3)
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
@@ -859,6 +862,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-checkbox@1.3.3':
+    resolution: {integrity: sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-collection@1.1.7':
     resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
     peerDependencies:
@@ -1268,14 +1284,6 @@ packages:
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
-
-  '@tabler/icons-react@3.36.1':
-    resolution: {integrity: sha512-/8nOXeNeMoze9xY/QyEKG65wuvRhkT3q9aytaur6Gj8bYU2A98YVJyLc9MRmc5nVvpy+bRlrrwK/Ykr8WGyUWg==}
-    peerDependencies:
-      react: '>= 16'
-
-  '@tabler/icons@3.36.1':
-    resolution: {integrity: sha512-f4Jg3Fof/Vru5ioix/UO4GX+sdDsF9wQo47FbtvG+utIYYVQ/QVAC0QYgcBbAjQGfbdOh2CCf0BgiFOF9Ixtjw==}
 
   '@tiptap/core@3.14.0':
     resolution: {integrity: sha512-nm0VWVA1Vq/jaKY3wyRXViL/kf78yMdH7qETpv4qZXDQLU+pdWV3IGoRTQTKESc7d8L1wL/2uCeByLNUJfrSIw==}
@@ -1853,6 +1861,11 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  lucide-react@0.469.0:
+    resolution: {integrity: sha512-28vvUnnKQ/dBwiCQtwJw7QauYnE7yd2Cyp4tTTJpvglX4EMpbflcdBgrgToX2j71B3YvugK/NH3BGUk+E/p/Fw==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -3133,6 +3146,21 @@ snapshots:
       '@types/react': 19.2.7
       '@types/react-dom': 18.3.7(@types/react@19.2.7)
 
+  '@radix-ui/react-checkbox@1.3.3(@types/react-dom@18.3.7(@types/react@19.2.7))(@types/react@19.2.7)(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.7(@types/react@19.2.7))(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@19.2.7))(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 18.3.7(@types/react@19.2.7)
+
   '@radix-ui/react-collection@1.1.7(@types/react-dom@18.3.7(@types/react@19.2.7))(@types/react@19.2.7)(react@19.2.3)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.2.3)
@@ -3454,13 +3482,6 @@ snapshots:
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
-
-  '@tabler/icons-react@3.36.1(react@19.2.3)':
-    dependencies:
-      '@tabler/icons': 3.36.1
-      react: 19.2.3
-
-  '@tabler/icons@3.36.1': {}
 
   '@tiptap/core@3.14.0(@tiptap/pm@3.14.0)':
     dependencies:
@@ -4031,6 +4052,10 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  lucide-react@0.469.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
 
   magic-string@0.30.21:
     dependencies:

--- a/src/components/AccordionClient.tsx
+++ b/src/components/AccordionClient.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useState } from 'react'
-import { IconChevronDown } from '@tabler/icons-react'
+import { ChevronDown } from 'lucide-react'
 import {
   marginValueToCSS,
   paddingValueToCSS,
@@ -67,7 +67,7 @@ function AccordionItem({
         style={textStyle}
       >
         <span>{item.title}</span>
-        <IconChevronDown
+        <ChevronDown
           className={cn(
             'h-4 w-4 shrink-0 transition-transform duration-200',
             isOpen && 'rotate-180'

--- a/src/components/interactive/Accordion.tsx
+++ b/src/components/interactive/Accordion.tsx
@@ -10,7 +10,7 @@
 
 import type { ComponentConfig } from '@measured/puck'
 import { useState } from 'react'
-import { IconChevronDown } from '@tabler/icons-react'
+import { ChevronDown } from 'lucide-react'
 import {
   marginValueToCSS,
   paddingValueToCSS,
@@ -77,7 +77,7 @@ function AccordionItem({
         style={textStyle}
       >
         <span>{item.title}</span>
-        <IconChevronDown
+        <ChevronDown
           className={cn(
             'h-4 w-4 shrink-0 transition-transform duration-200',
             isOpen && 'rotate-180'

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { IconX } from "@tabler/icons-react"
+import { X } from "lucide-react"
 import { cn } from "../../lib/utils"
 
 const Dialog = DialogPrimitive.Root
@@ -44,7 +44,7 @@ const DialogContent = React.forwardRef<
     >
       {children}
       <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <IconX className="h-4 w-4" />
+        <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
@@ -77,7 +77,7 @@ const DialogContentFullscreen = React.forwardRef<
       {children}
       {!hideCloseButton && (
         <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-          <IconX className="h-4 w-4" />
+          <X className="h-4 w-4" />
           <span className="sr-only">Close</span>
         </DialogPrimitive.Close>
       )}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import * as SelectPrimitive from "@radix-ui/react-select"
-import { IconCheck, IconChevronDown, IconChevronUp } from "@tabler/icons-react"
+import { Check, ChevronDown, ChevronUp } from "lucide-react"
 import { cn } from "../../lib/utils"
 
 const Select = SelectPrimitive.Root
@@ -25,7 +25,7 @@ const SelectTrigger = React.forwardRef<
   >
     {children}
     <SelectPrimitive.Icon asChild>
-      <IconChevronDown className="h-4 w-4 opacity-50" />
+      <ChevronDown className="h-4 w-4 opacity-50" />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
 ))
@@ -43,7 +43,7 @@ const SelectScrollUpButton = React.forwardRef<
     )}
     {...props}
   >
-    <IconChevronUp className="h-4 w-4" />
+    <ChevronUp className="h-4 w-4" />
   </SelectPrimitive.ScrollUpButton>
 ))
 SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
@@ -60,7 +60,7 @@ const SelectScrollDownButton = React.forwardRef<
     )}
     {...props}
   >
-    <IconChevronDown className="h-4 w-4" />
+    <ChevronDown className="h-4 w-4" />
   </SelectPrimitive.ScrollDownButton>
 ))
 SelectScrollDownButton.displayName =
@@ -124,7 +124,7 @@ const SelectItem = React.forwardRef<
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
       <SelectPrimitive.ItemIndicator>
-        <IconCheck className="h-4 w-4" />
+        <Check className="h-4 w-4" />
       </SelectPrimitive.ItemIndicator>
     </span>
 

--- a/src/editor/components/HeaderActions.tsx
+++ b/src/editor/components/HeaderActions.tsx
@@ -3,18 +3,18 @@
 import { memo, useCallback, type ReactNode } from 'react'
 import { createUsePuck, type Data } from '@measured/puck'
 import {
-  IconArrowLeft,
-  IconDeviceFloppy,
-  IconExternalLink,
-  IconLoader2,
-  IconCheck,
-  IconHandClick,
-  IconPointer,
-  IconUpload,
-  IconX,
-  IconAlertTriangle,
-  IconEye,
-} from '@tabler/icons-react'
+  ArrowLeft,
+  Save,
+  ExternalLink,
+  Loader2,
+  Check,
+  MousePointerClick,
+  MousePointer,
+  Upload,
+  X,
+  AlertTriangle,
+  Eye,
+} from 'lucide-react'
 import { VersionHistory } from './VersionHistory'
 import { cn } from '../../lib/utils'
 
@@ -207,7 +207,7 @@ export const HeaderActions = memo(function HeaderActions({
         onClick={onBack}
         className={cn(btnBase, "px-3 py-1.5 bg-white text-gray-700 border border-gray-300 rounded hover:bg-gray-50")}
       >
-        <IconArrowLeft className="h-4 w-4 mr-1 flex-shrink-0" />
+        <ArrowLeft className="h-4 w-4 mr-1 flex-shrink-0" />
         Back
       </button>
 
@@ -255,7 +255,7 @@ export const HeaderActions = memo(function HeaderActions({
                 : "bg-gray-100 text-gray-500 border-gray-200"
             )}
           >
-            <IconPointer className="h-3.5 w-3.5" />
+            <MousePointer className="h-3.5 w-3.5" />
             Edit
           </button>
           <button
@@ -268,7 +268,7 @@ export const HeaderActions = memo(function HeaderActions({
                 : "bg-gray-100 text-gray-500 border-gray-200"
             )}
           >
-            <IconHandClick className="h-3.5 w-3.5" />
+            <MousePointerClick className="h-3.5 w-3.5" />
             Interactive
           </button>
         </div>
@@ -277,7 +277,7 @@ export const HeaderActions = memo(function HeaderActions({
       {/* Status indicators */}
       {lastSaved && !saveError && (
         <span className="text-xs text-gray-500 flex items-center gap-1 whitespace-nowrap">
-          <IconCheck className="h-3 w-3 flex-shrink-0" />
+          <Check className="h-3 w-3 flex-shrink-0" />
           Saved {lastSaved.toLocaleTimeString()}
         </span>
       )}
@@ -292,7 +292,7 @@ export const HeaderActions = memo(function HeaderActions({
           onClick={() => {}} // Modal is already open when saveError exists
           className="flex items-center gap-1.5 px-2.5 py-1.5 bg-red-50 border border-red-200 rounded-md text-red-700 text-xs font-medium"
         >
-          <IconAlertTriangle className="h-4 w-4 text-red-500 flex-shrink-0" />
+          <AlertTriangle className="h-4 w-4 text-red-500 flex-shrink-0" />
           Error
         </button>
       )}
@@ -310,7 +310,7 @@ export const HeaderActions = memo(function HeaderActions({
             {/* Modal Header */}
             <div className="flex items-center gap-3 px-5 py-4 border-b border-gray-200 bg-red-50">
               <div className="flex-shrink-0 w-10 h-10 rounded-full bg-red-100 flex items-center justify-center">
-                <IconAlertTriangle className="h-5 w-5 text-red-600" />
+                <AlertTriangle className="h-5 w-5 text-red-600" />
               </div>
               <div>
                 <h3 className="text-base font-semibold text-gray-900">Save Failed</h3>
@@ -348,7 +348,7 @@ export const HeaderActions = memo(function HeaderActions({
             "px-3 py-1.5 bg-blue-600 text-white border border-blue-600 rounded hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
           )}
         >
-          <IconEye className="h-4 w-4 mr-1 flex-shrink-0" />
+          <Eye className="h-4 w-4 mr-1 flex-shrink-0" />
           Preview
         </button>
       )}
@@ -360,7 +360,7 @@ export const HeaderActions = memo(function HeaderActions({
           onClick={onPreview}
           className={cn(btnBase, "px-3 py-1.5 bg-white text-gray-700 border border-gray-300 rounded hover:bg-gray-50")}
         >
-          <IconExternalLink className="h-4 w-4 mr-1 flex-shrink-0" />
+          <ExternalLink className="h-4 w-4 mr-1 flex-shrink-0" />
           View
         </button>
       )}
@@ -386,9 +386,9 @@ export const HeaderActions = memo(function HeaderActions({
           )}
         >
           {isSaving ? (
-            <IconLoader2 className="h-4 w-4 mr-1 flex-shrink-0 animate-spin" />
+            <Loader2 className="h-4 w-4 mr-1 flex-shrink-0 animate-spin" />
           ) : (
-            <IconDeviceFloppy className="h-4 w-4 mr-1 flex-shrink-0" />
+            <Save className="h-4 w-4 mr-1 flex-shrink-0" />
           )}
           Save
         </button>
@@ -406,9 +406,9 @@ export const HeaderActions = memo(function HeaderActions({
           )}
         >
           {isSaving ? (
-            <IconLoader2 className="h-4 w-4 mr-1 flex-shrink-0 animate-spin" />
+            <Loader2 className="h-4 w-4 mr-1 flex-shrink-0 animate-spin" />
           ) : (
-            <IconUpload className="h-4 w-4 mr-1 flex-shrink-0" />
+            <Upload className="h-4 w-4 mr-1 flex-shrink-0" />
           )}
           Publish
         </button>

--- a/src/editor/components/LoadingState.tsx
+++ b/src/editor/components/LoadingState.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { IconLoader2 } from '@tabler/icons-react'
+import { Loader2 } from 'lucide-react'
 
 export interface LoadingStateProps {
   /**
@@ -19,7 +19,7 @@ export function LoadingState({ message = 'Loading editor...' }: LoadingStateProp
   return (
     <div className="h-screen flex items-center justify-center bg-gray-50">
       <div className="text-center">
-        <IconLoader2 className="h-8 w-8 animate-spin text-gray-600 mx-auto mb-4" />
+        <Loader2 className="h-8 w-8 animate-spin text-gray-600 mx-auto mb-4" />
         <p className="text-gray-600">{message}</p>
       </div>
     </div>

--- a/src/editor/components/PreviewModal.tsx
+++ b/src/editor/components/PreviewModal.tsx
@@ -7,10 +7,10 @@ import {
   DialogContentFullscreen,
 } from '../../components/ui/dialog'
 import {
-  IconX,
-  IconExternalLink,
-  IconAlertTriangle,
-} from '@tabler/icons-react'
+  X,
+  ExternalLink,
+  AlertTriangle,
+} from 'lucide-react'
 import { cn } from '../../lib/utils'
 import { PageRenderer } from '../../render/PageRenderer'
 import type { LayoutDefinition } from '../../layouts'
@@ -148,7 +148,7 @@ export const PreviewModal = memo(function PreviewModal({
               className="flex items-center gap-2 px-3 py-2 text-sm font-medium text-white bg-gray-900 hover:bg-gray-800 rounded-md transition-colors"
               title="Close preview (Esc)"
             >
-              <IconX className="h-4 w-4" />
+              <X className="h-4 w-4" />
               Close Preview
             </button>
 
@@ -160,7 +160,7 @@ export const PreviewModal = memo(function PreviewModal({
                 className="flex items-center gap-2 px-3 py-2 text-sm text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-md transition-colors"
                 title="Open published page in new tab"
               >
-                <IconExternalLink className="h-4 w-4" />
+                <ExternalLink className="h-4 w-4" />
                 View Page
               </button>
             )}
@@ -198,7 +198,7 @@ export const PreviewModal = memo(function PreviewModal({
               {/* Header */}
               <div className="flex items-center gap-3 px-5 py-4 border-b border-gray-200 bg-amber-50">
                 <div className="flex-shrink-0 w-10 h-10 rounded-full bg-amber-100 flex items-center justify-center">
-                  <IconAlertTriangle className="h-5 w-5 text-amber-600" />
+                  <AlertTriangle className="h-5 w-5 text-amber-600" />
                 </div>
                 <div>
                   <h3 className="text-base font-semibold text-gray-900">Navigate away?</h3>

--- a/src/editor/components/VersionHistory.tsx
+++ b/src/editor/components/VersionHistory.tsx
@@ -2,13 +2,13 @@
 
 import { useState, useCallback, useEffect, useRef, memo } from 'react'
 import {
-  IconHistory,
-  IconLoader2,
-  IconCheck,
-  IconRotate,
-  IconX,
-  IconChevronDown,
-} from '@tabler/icons-react'
+  History,
+  Loader2,
+  Check,
+  RotateCcw,
+  X,
+  ChevronDown,
+} from 'lucide-react'
 
 /**
  * Version entry from Payload's versions system
@@ -196,9 +196,9 @@ export const VersionHistory = memo(function VersionHistory({
         disabled={disabled}
         className={`${secondaryBtn} disabled:opacity-50 disabled:cursor-not-allowed`}
       >
-        <IconHistory className="h-4 w-4 mr-1 flex-shrink-0" />
+        <History className="h-4 w-4 mr-1 flex-shrink-0" />
         History
-        <IconChevronDown className="h-3 w-3 ml-1 flex-shrink-0" />
+        <ChevronDown className="h-3 w-3 ml-1 flex-shrink-0" />
       </button>
 
       {/* Dropdown panel */}
@@ -216,7 +216,7 @@ export const VersionHistory = memo(function VersionHistory({
               onClick={() => setIsOpen(false)}
               className="text-gray-400 hover:text-gray-600 transition-colors p-1"
             >
-              <IconX className="h-4 w-4" />
+              <X className="h-4 w-4" />
             </button>
           </div>
 
@@ -226,7 +226,7 @@ export const VersionHistory = memo(function VersionHistory({
               <div
                 className="flex items-center justify-center p-8"
               >
-                <IconLoader2 className="h-5 w-5 animate-spin text-gray-400" />
+                <Loader2 className="h-5 w-5 animate-spin text-gray-400" />
               </div>
             ) : error ? (
               <div
@@ -295,9 +295,9 @@ export const VersionHistory = memo(function VersionHistory({
                         className="text-xs font-medium text-blue-600 hover:text-blue-800 transition-colors disabled:opacity-50 flex items-center gap-1 px-2 py-1 flex-shrink-0"
                       >
                         {isRestoring ? (
-                          <IconLoader2 className="h-3 w-3 animate-spin" />
+                          <Loader2 className="h-3 w-3 animate-spin" />
                         ) : (
-                          <IconRotate className="h-3 w-3" />
+                          <RotateCcw className="h-3 w-3" />
                         )}
                         Restore
                       </button>
@@ -306,7 +306,7 @@ export const VersionHistory = memo(function VersionHistory({
                     {/* Current indicator */}
                     {index === 0 && (
                       <span className="text-gray-400 flex-shrink-0">
-                        <IconCheck className="h-4 w-4" />
+                        <Check className="h-4 w-4" />
                       </span>
                     )}
                   </div>

--- a/src/fields/AlignmentField.tsx
+++ b/src/fields/AlignmentField.tsx
@@ -10,11 +10,11 @@
 import React, { useCallback, memo } from 'react'
 import type { CustomField } from '@measured/puck'
 import {
-  IconLayoutAlignLeft,
-  IconLayoutAlignCenter,
-  IconLayoutAlignRight,
-  IconX,
-} from '@tabler/icons-react'
+  AlignLeft,
+  AlignCenter,
+  AlignRight,
+  X,
+} from 'lucide-react'
 import { Button } from '../components/ui/button'
 import { Label } from '../components/ui/label'
 import { cn } from '../lib/utils'
@@ -56,9 +56,9 @@ function AlignmentFieldInner({
   }, [onChange])
 
   const alignments = [
-    { value: 'left' as Alignment, icon: IconLayoutAlignLeft, title: 'Align left' },
-    { value: 'center' as Alignment, icon: IconLayoutAlignCenter, title: 'Align center' },
-    { value: 'right' as Alignment, icon: IconLayoutAlignRight, title: 'Align right' },
+    { value: 'left' as Alignment, icon: AlignLeft, title: 'Align left' },
+    { value: 'center' as Alignment, icon: AlignCenter, title: 'Align center' },
+    { value: 'right' as Alignment, icon: AlignRight, title: 'Align right' },
   ]
 
   return (
@@ -77,7 +77,7 @@ function AlignmentFieldInner({
             className="text-muted-foreground hover:text-destructive"
             title="Reset to default"
           >
-            <IconX className="h-4 w-4" />
+            <X className="h-4 w-4" />
           </Button>
         )}
       </div>

--- a/src/fields/AnimationField.tsx
+++ b/src/fields/AnimationField.tsx
@@ -14,7 +14,7 @@
 
 import React, { useCallback, memo, useState } from 'react'
 import type { CustomField } from '@measured/puck'
-import { IconX, IconChevronDown, IconChevronRight } from '@tabler/icons-react'
+import { X, ChevronDown, ChevronRight } from 'lucide-react'
 import type {
   AnimationValue,
   AdvancedEasingFunction,
@@ -102,9 +102,9 @@ function CollapsibleSection({ title, defaultOpen = false, children }: Collapsibl
       >
         <span className="text-xs font-medium text-muted-foreground">{title}</span>
         {isOpen ? (
-          <IconChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+          <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
         ) : (
-          <IconChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+          <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
         )}
       </button>
       {isOpen && <div className="p-3 space-y-3">{children}</div>}
@@ -285,7 +285,7 @@ function AnimationFieldInner({
             className="text-muted-foreground hover:text-destructive"
             title="Reset to default"
           >
-            <IconX className="h-4 w-4" />
+            <X className="h-4 w-4" />
           </Button>
         )}
       </div>

--- a/src/fields/BackgroundField.tsx
+++ b/src/fields/BackgroundField.tsx
@@ -12,7 +12,7 @@
 
 import React, { useCallback, memo } from 'react'
 import type { CustomField } from '@measured/puck'
-import { IconX } from '@tabler/icons-react'
+import { X } from 'lucide-react'
 import type {
   BackgroundValue,
   BackgroundImageValue,
@@ -616,7 +616,7 @@ function BackgroundFieldInner({
             title="Clear background"
             className="flex items-center justify-center w-6 h-6 rounded border-none bg-transparent cursor-pointer text-muted-foreground hover:bg-accent hover:text-destructive"
           >
-            <IconX className="w-4 h-4" />
+            <X className="w-4 h-4" />
           </button>
         )}
       </div>

--- a/src/fields/BorderField.tsx
+++ b/src/fields/BorderField.tsx
@@ -14,12 +14,12 @@
 import React, { useCallback, memo } from 'react'
 import type { CustomField } from '@measured/puck'
 import {
-  IconX,
-  IconBorderTop,
-  IconBorderRight,
-  IconBorderBottom,
-  IconBorderLeft,
-} from '@tabler/icons-react'
+  X,
+  ArrowUp,
+  ArrowRight,
+  ArrowDown,
+  ArrowLeft,
+} from 'lucide-react'
 import { ColorPickerField } from './ColorPickerField'
 import type { BorderValue, ColorValue } from './shared'
 import { Button } from '../components/ui/button'
@@ -162,7 +162,7 @@ function BorderFieldInner({
             className="text-muted-foreground hover:text-destructive"
             title="Clear border"
           >
-            <IconX className="h-4 w-4" />
+            <X className="h-4 w-4" />
           </Button>
         )}
       </div>
@@ -273,7 +273,7 @@ function BorderFieldInner({
               )}
               title="Top border"
             >
-              <IconBorderTop className="h-4 w-4" />
+              <ArrowUp className="h-4 w-4" />
             </Button>
             <Button
               type="button"
@@ -286,7 +286,7 @@ function BorderFieldInner({
               )}
               title="Right border"
             >
-              <IconBorderRight className="h-4 w-4" />
+              <ArrowRight className="h-4 w-4" />
             </Button>
             <Button
               type="button"
@@ -299,7 +299,7 @@ function BorderFieldInner({
               )}
               title="Bottom border"
             >
-              <IconBorderBottom className="h-4 w-4" />
+              <ArrowDown className="h-4 w-4" />
             </Button>
             <Button
               type="button"
@@ -312,7 +312,7 @@ function BorderFieldInner({
               )}
               title="Left border"
             >
-              <IconBorderLeft className="h-4 w-4" />
+              <ArrowLeft className="h-4 w-4" />
             </Button>
           </div>
           <p className="text-[10px] text-muted-foreground text-center">

--- a/src/fields/ColorPickerField.tsx
+++ b/src/fields/ColorPickerField.tsx
@@ -13,7 +13,7 @@
 
 import React, { useState, useCallback, memo } from 'react'
 import type { CustomField } from '@measured/puck'
-import { IconX } from '@tabler/icons-react'
+import { X } from 'lucide-react'
 import type { ColorValue } from './shared'
 import { useTheme } from '../theme'
 import { Button } from '../components/ui/button'
@@ -204,7 +204,7 @@ function ColorPickerFieldInner({
             title="Clear color"
             className="flex items-center justify-center w-8 h-8 rounded border-none bg-transparent cursor-pointer text-muted-foreground flex-shrink-0 hover:bg-accent hover:text-destructive"
           >
-            <IconX className="w-4 h-4" />
+            <X className="w-4 h-4" />
           </button>
         )}
       </div>

--- a/src/fields/DimensionsField.tsx
+++ b/src/fields/DimensionsField.tsx
@@ -15,16 +15,16 @@
 import React, { useCallback, memo, useState } from 'react'
 import type { CustomField } from '@measured/puck'
 import {
-  IconX,
-  IconLayoutAlignLeft,
-  IconLayoutAlignCenter,
-  IconLayoutAlignRight,
-  IconArrowsHorizontal,
-  IconContainer,
-  IconAdjustments,
-  IconChevronDown,
-  IconChevronUp,
-} from '@tabler/icons-react'
+  X,
+  AlignStartHorizontal,
+  AlignCenterHorizontal,
+  AlignEndHorizontal,
+  MoveHorizontal,
+  Square,
+  SlidersHorizontal,
+  ChevronDown,
+  ChevronUp,
+} from 'lucide-react'
 import type {
   DimensionsValue,
   DimensionConstraint,
@@ -363,15 +363,15 @@ function DimensionsFieldInner({
 
   // Mode labels
   const modeConfig = [
-    { mode: 'full' as DimensionsMode, icon: IconArrowsHorizontal, label: 'Full', title: 'Full width (100%)' },
-    { mode: 'contained' as DimensionsMode, icon: IconContainer, label: 'Contain', title: 'Contained (centered with max-width)' },
-    { mode: 'custom' as DimensionsMode, icon: IconAdjustments, label: 'Custom', title: 'Custom width settings' },
+    { mode: 'full' as DimensionsMode, icon: MoveHorizontal, label: 'Full', title: 'Full width (100%)' },
+    { mode: 'contained' as DimensionsMode, icon: Square, label: 'Contain', title: 'Contained (centered with max-width)' },
+    { mode: 'custom' as DimensionsMode, icon: SlidersHorizontal, label: 'Custom', title: 'Custom width settings' },
   ]
 
   const alignmentConfig = [
-    { alignment: 'left' as ContentAlignment, icon: IconLayoutAlignLeft, title: 'Align left' },
-    { alignment: 'center' as ContentAlignment, icon: IconLayoutAlignCenter, title: 'Align center' },
-    { alignment: 'right' as ContentAlignment, icon: IconLayoutAlignRight, title: 'Align right' },
+    { alignment: 'left' as ContentAlignment, icon: AlignStartHorizontal, title: 'Align left' },
+    { alignment: 'center' as ContentAlignment, icon: AlignCenterHorizontal, title: 'Align center' },
+    { alignment: 'right' as ContentAlignment, icon: AlignEndHorizontal, title: 'Align right' },
   ]
 
   const showWidthControls = currentValue.mode !== 'full'
@@ -393,7 +393,7 @@ function DimensionsFieldInner({
             className="text-muted-foreground hover:text-destructive"
             title="Reset to default"
           >
-            <IconX className="h-4 w-4" />
+            <X className="h-4 w-4" />
           </Button>
         )}
       </div>
@@ -638,12 +638,12 @@ function DimensionsFieldInner({
         >
           {advancedMode ? (
             <>
-              <IconChevronUp className="h-3.5 w-3.5 mr-1" />
+              <ChevronUp className="h-3.5 w-3.5 mr-1" />
               Hide Advanced
             </>
           ) : (
             <>
-              <IconChevronDown className="h-3.5 w-3.5 mr-1" />
+              <ChevronDown className="h-3.5 w-3.5 mr-1" />
               Show Advanced
             </>
           )}

--- a/src/fields/FlexAlignmentField.tsx
+++ b/src/fields/FlexAlignmentField.tsx
@@ -11,17 +11,17 @@
 import React, { useCallback, memo } from 'react'
 import type { CustomField } from '@measured/puck'
 import {
-  IconLayoutAlignLeft,
-  IconLayoutAlignCenter,
-  IconLayoutAlignRight,
-  IconLayoutDistributeHorizontal,
-  IconSpacingHorizontal,
-  IconLayoutAlignTop,
-  IconLayoutAlignMiddle,
-  IconLayoutAlignBottom,
-  IconArrowsVertical,
-  IconX,
-} from '@tabler/icons-react'
+  AlignLeft,
+  AlignCenter,
+  AlignRight,
+  AlignHorizontalDistributeCenter,
+  GripHorizontal,
+  AlignStartVertical,
+  AlignCenterVertical,
+  AlignEndVertical,
+  MoveVertical,
+  X,
+} from 'lucide-react'
 import { Button } from '../components/ui/button'
 import { Label } from '../components/ui/label'
 import { cn } from '../lib/utils'
@@ -71,11 +71,11 @@ function JustifyContentFieldInner({
   }, [onChange])
 
   const options = [
-    { value: 'flex-start' as JustifyContent, icon: IconLayoutAlignLeft, title: 'Start' },
-    { value: 'center' as JustifyContent, icon: IconLayoutAlignCenter, title: 'Center' },
-    { value: 'flex-end' as JustifyContent, icon: IconLayoutAlignRight, title: 'End' },
-    { value: 'space-between' as JustifyContent, icon: IconLayoutDistributeHorizontal, title: 'Space Between' },
-    { value: 'space-around' as JustifyContent, icon: IconSpacingHorizontal, title: 'Space Around' },
+    { value: 'flex-start' as JustifyContent, icon: AlignLeft, title: 'Start' },
+    { value: 'center' as JustifyContent, icon: AlignCenter, title: 'Center' },
+    { value: 'flex-end' as JustifyContent, icon: AlignRight, title: 'End' },
+    { value: 'space-between' as JustifyContent, icon: AlignHorizontalDistributeCenter, title: 'Space Between' },
+    { value: 'space-around' as JustifyContent, icon: GripHorizontal, title: 'Space Around' },
   ]
 
   return (
@@ -93,7 +93,7 @@ function JustifyContentFieldInner({
             className="text-muted-foreground hover:text-destructive"
             title="Reset to default"
           >
-            <IconX className="h-4 w-4" />
+            <X className="h-4 w-4" />
           </Button>
         )}
       </div>
@@ -148,10 +148,10 @@ function AlignItemsFieldInner({
   }, [onChange])
 
   const options = [
-    { value: 'flex-start' as AlignItems, icon: IconLayoutAlignTop, title: 'Start' },
-    { value: 'center' as AlignItems, icon: IconLayoutAlignMiddle, title: 'Center' },
-    { value: 'flex-end' as AlignItems, icon: IconLayoutAlignBottom, title: 'End' },
-    { value: 'stretch' as AlignItems, icon: IconArrowsVertical, title: 'Stretch' },
+    { value: 'flex-start' as AlignItems, icon: AlignStartVertical, title: 'Start' },
+    { value: 'center' as AlignItems, icon: AlignCenterVertical, title: 'Center' },
+    { value: 'flex-end' as AlignItems, icon: AlignEndVertical, title: 'End' },
+    { value: 'stretch' as AlignItems, icon: MoveVertical, title: 'Stretch' },
   ]
 
   return (
@@ -169,7 +169,7 @@ function AlignItemsFieldInner({
             className="text-muted-foreground hover:text-destructive"
             title="Reset to default"
           >
-            <IconX className="h-4 w-4" />
+            <X className="h-4 w-4" />
           </Button>
         )}
       </div>

--- a/src/fields/GradientEditor.tsx
+++ b/src/fields/GradientEditor.tsx
@@ -13,7 +13,7 @@
  */
 
 import React, { useCallback, memo, useState } from 'react'
-import { IconPlus, IconTrash } from '@tabler/icons-react'
+import { Plus, Trash2 } from 'lucide-react'
 import type { GradientValue, GradientStop, ColorValue } from './shared'
 import { colorValueToCSS } from './shared'
 import { Button } from '../components/ui/button'
@@ -203,7 +203,7 @@ function GradientStopEditorInner({
             className="p-1 text-muted-foreground hover:text-destructive hover:bg-destructive/10 rounded flex-shrink-0"
             title="Remove stop"
           >
-            <IconTrash className="w-4 h-4" />
+            <Trash2 className="w-4 h-4" />
           </button>
         )}
       </div>
@@ -442,7 +442,7 @@ function GradientEditorInner({ value, onChange, readOnly }: GradientEditorProps)
               onClick={handleAddStop}
               className="h-6 text-xs px-2"
             >
-              <IconPlus className="w-3 h-3 mr-1" />
+              <Plus className="w-3 h-3 mr-1" />
               Add Stop
             </Button>
           )}

--- a/src/fields/LockedField.tsx
+++ b/src/fields/LockedField.tsx
@@ -15,7 +15,7 @@
 
 import React, { useState } from 'react'
 import type { CustomField } from '@measured/puck'
-import { IconLock, IconLockOpen } from '@tabler/icons-react'
+import { Lock, Unlock } from 'lucide-react'
 
 // =============================================================================
 // Types
@@ -75,9 +75,9 @@ export function LockedTextField({
           title={isLocked ? 'Click to unlock' : 'Click to lock'}
         >
           {isLocked ? (
-            <IconLock size={14} />
+            <Lock size={14} />
           ) : (
-            <IconLockOpen size={14} />
+            <Unlock size={14} />
           )}
         </button>
       </div>
@@ -105,7 +105,7 @@ export function LockedTextField({
           }}
         />
         {isLocked && (
-          <IconLock
+          <Lock
             size={14}
             style={{
               position: 'absolute',
@@ -174,9 +174,9 @@ export function LockedRadioField({
           title={isLocked ? 'Click to unlock' : 'Click to lock'}
         >
           {isLocked ? (
-            <IconLock size={14} />
+            <Lock size={14} />
           ) : (
-            <IconLockOpen size={14} />
+            <Unlock size={14} />
           )}
         </button>
       </div>

--- a/src/fields/MarginField.tsx
+++ b/src/fields/MarginField.tsx
@@ -12,7 +12,7 @@
 
 import React, { useCallback, memo } from 'react'
 import type { CustomField } from '@measured/puck'
-import { IconLink, IconLinkOff } from '@tabler/icons-react'
+import { Link, Unlink } from 'lucide-react'
 import type { PaddingValue } from './shared'
 import { Button } from '../components/ui/button'
 import { Input } from '../components/ui/input'
@@ -163,9 +163,9 @@ function MarginFieldInner({
             title={isLinked ? 'Click to unlink (set sides individually)' : 'Click to link (all sides same value)'}
           >
             {isLinked ? (
-              <IconLink className="h-4 w-4" />
+              <Link className="h-4 w-4" />
             ) : (
-              <IconLinkOff className="h-4 w-4" />
+              <Unlink className="h-4 w-4" />
             )}
           </Button>
         )}

--- a/src/fields/MediaField.tsx
+++ b/src/fields/MediaField.tsx
@@ -9,7 +9,7 @@
 
 import React, { useState, useEffect, useCallback, memo } from 'react'
 import type { CustomField } from '@measured/puck'
-import { IconPhoto, IconX, IconSearch, IconLoader2, IconUpload, IconAlertCircle, IconLink } from '@tabler/icons-react'
+import { Image, X, Search, Loader2, Upload, AlertCircle, Link } from 'lucide-react'
 import { Button } from '../components/ui/button'
 import { Input } from '../components/ui/input'
 import { Label } from '../components/ui/label'
@@ -348,13 +348,13 @@ function MediaFieldInner({
                   className="absolute -top-2 -right-2 p-1 bg-destructive text-destructive-foreground rounded-full opacity-0 group-hover:opacity-100 transition-opacity"
                   aria-label="Remove image"
                 >
-                  <IconX className="h-3 w-3" />
+                  <X className="h-3 w-3" />
                 </button>
               )}
             </div>
           ) : (
             <div className="w-24 h-24 bg-muted rounded-md border border-dashed border-input flex items-center justify-center">
-              <IconPhoto className="h-8 w-8 text-muted-foreground" />
+              <Image className="h-8 w-8 text-muted-foreground" />
             </div>
           )}
 
@@ -385,7 +385,7 @@ function MediaFieldInner({
         {/* Current URL display */}
         {value?.url && (
           <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-            <IconLink className="h-3 w-3 flex-shrink-0" />
+            <Link className="h-3 w-3 flex-shrink-0" />
             <span className="truncate max-w-[280px]" title={value.url}>
               {value.url}
             </span>
@@ -443,7 +443,7 @@ function MediaFieldInner({
           {/* Search (browse tab only) */}
           {activeTab === 'browse' && (
             <div className="relative flex-shrink-0">
-              <IconSearch className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
               <Input
                 type="text"
                 placeholder="Search by alt text..."
@@ -507,7 +507,7 @@ function MediaFieldInner({
                       >
                         {loading ? (
                           <>
-                            <IconLoader2 className="h-4 w-4 mr-2 animate-spin" />
+                            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
                             Loading...
                           </>
                         ) : (
@@ -547,7 +547,7 @@ function MediaFieldInner({
                     {/* Error */}
                     {uploadState.error && (
                       <div className="p-3 bg-destructive/10 border border-destructive/30 rounded-md text-destructive text-sm flex items-start gap-2">
-                        <IconAlertCircle className="h-4 w-4 flex-shrink-0 mt-0.5" />
+                        <AlertCircle className="h-4 w-4 flex-shrink-0 mt-0.5" />
                         <span>{uploadState.error}</span>
                       </div>
                     )}
@@ -557,12 +557,12 @@ function MediaFieldInner({
                       <Button onClick={handleUpload} disabled={uploadState.uploading}>
                         {uploadState.uploading ? (
                           <>
-                            <IconLoader2 className="h-4 w-4 mr-2 animate-spin" />
+                            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
                             Uploading...
                           </>
                         ) : (
                           <>
-                            <IconUpload className="h-4 w-4 mr-2" />
+                            <Upload className="h-4 w-4 mr-2" />
                             Upload & Select
                           </>
                         )}
@@ -578,7 +578,7 @@ function MediaFieldInner({
                   </div>
                 ) : (
                   <div className="text-center">
-                    <IconPhoto className="h-16 w-16 text-muted mx-auto mb-4" />
+                    <Image className="h-16 w-16 text-muted mx-auto mb-4" />
                     <label className="cursor-pointer">
                       <Button asChild>
                         <span>Select Image</span>
@@ -604,7 +604,7 @@ function MediaFieldInner({
               <div className="flex flex-col items-center justify-center h-full min-h-[300px]">
                 <div className="w-full max-w-md space-y-4">
                   <div className="text-center mb-6">
-                    <IconLink className="h-12 w-12 text-muted-foreground mx-auto mb-2" />
+                    <Link className="h-12 w-12 text-muted-foreground mx-auto mb-2" />
                     <p className="text-sm text-muted-foreground">
                       Enter an image URL from an external source
                     </p>
@@ -648,7 +648,7 @@ function MediaFieldInner({
                       />
                       {!urlState.previewLoaded && (
                         <div className="absolute inset-0 flex items-center justify-center bg-muted">
-                          <IconLoader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+                          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
                         </div>
                       )}
                     </div>
@@ -657,7 +657,7 @@ function MediaFieldInner({
                   {/* Error */}
                   {urlState.error && (
                     <div className="p-3 bg-destructive/10 border border-destructive/30 rounded-md text-destructive text-sm flex items-start gap-2">
-                      <IconAlertCircle className="h-4 w-4 flex-shrink-0 mt-0.5" />
+                      <AlertCircle className="h-4 w-4 flex-shrink-0 mt-0.5" />
                       <span>{urlState.error}</span>
                     </div>
                   )}
@@ -668,7 +668,7 @@ function MediaFieldInner({
                       onClick={handleUrlSubmit}
                       disabled={!urlState.url || urlState.loading}
                     >
-                      <IconLink className="h-4 w-4 mr-2" />
+                      <Link className="h-4 w-4 mr-2" />
                       Use This URL
                     </Button>
                     {urlState.url && (

--- a/src/fields/PaddingField.tsx
+++ b/src/fields/PaddingField.tsx
@@ -11,7 +11,7 @@
 
 import React, { useCallback, memo } from 'react'
 import type { CustomField } from '@measured/puck'
-import { IconLink, IconLinkOff } from '@tabler/icons-react'
+import { Link, Unlink } from 'lucide-react'
 import type { PaddingValue } from './shared'
 import { Button } from '../components/ui/button'
 import { Input } from '../components/ui/input'
@@ -159,9 +159,9 @@ function PaddingFieldInner({
             title={isLinked ? 'Click to unlink (set sides individually)' : 'Click to link (all sides same value)'}
           >
             {isLinked ? (
-              <IconLink className="h-4 w-4" />
+              <Link className="h-4 w-4" />
             ) : (
-              <IconLinkOff className="h-4 w-4" />
+              <Unlink className="h-4 w-4" />
             )}
           </Button>
         )}

--- a/src/fields/ResetField.tsx
+++ b/src/fields/ResetField.tsx
@@ -13,7 +13,7 @@ import React, { memo, useCallback } from 'react'
 import type { CustomField } from '@measured/puck'
 import { createUsePuck } from '@measured/puck'
 import type { Data } from '@measured/puck'
-import { IconRefresh } from '@tabler/icons-react'
+import { RefreshCw } from 'lucide-react'
 import { Button } from '../components/ui/button'
 
 // Create usePuck hook for accessing editor state
@@ -48,7 +48,7 @@ function ResetFieldInner({
         disabled={disabled}
         className="w-full text-muted-foreground hover:text-destructive hover:bg-destructive/10 gap-1.5"
       >
-        <IconRefresh className="h-3.5 w-3.5" />
+        <RefreshCw className="h-3.5 w-3.5" />
         {label}
       </Button>
     </div>

--- a/src/fields/ResponsiveField.tsx
+++ b/src/fields/ResponsiveField.tsx
@@ -4,20 +4,19 @@
  * ResponsiveField - Generic wrapper for breakpoint-specific field overrides
  *
  * This component wraps any existing field to provide responsive overrides
- * at different breakpoints (base, sm, md, lg, xl). It uses sparse storage,
+ * at different breakpoints (xs, sm, md, lg, xl). It uses sparse storage,
  * only storing values for breakpoints that have explicit overrides.
  */
 
 import React, { useState, useCallback, memo } from 'react'
 import type { CustomField } from '@measured/puck'
 import {
-  IconDeviceMobile,
-  IconDeviceTablet,
-  IconDeviceLaptop,
-  IconDeviceDesktop,
-  IconDevices,
-  IconX,
-} from '@tabler/icons-react'
+  Smartphone,
+  Tablet,
+  Laptop,
+  Monitor,
+  X,
+} from 'lucide-react'
 import { Button } from '../components/ui/button'
 import { Label } from '../components/ui/label'
 import { cn } from '../lib/utils'
@@ -39,7 +38,7 @@ interface ResponsiveFieldProps<T> {
     onChange: (v: T | null) => void
     readOnly?: boolean
   }) => React.ReactNode
-  /** Default value for the base breakpoint */
+  /** Default value for the xs breakpoint */
   defaultValue?: T
 }
 
@@ -48,11 +47,11 @@ interface ResponsiveFieldProps<T> {
 // =============================================================================
 
 const BREAKPOINT_ICONS: Record<Breakpoint, React.ComponentType<{ className?: string }>> = {
-  base: IconDevices,
-  sm: IconDeviceMobile,
-  md: IconDeviceTablet,
-  lg: IconDeviceLaptop,
-  xl: IconDeviceDesktop,
+  xs: Smartphone,
+  sm: Smartphone,
+  md: Tablet,
+  lg: Laptop,
+  xl: Monitor,
 }
 
 // =============================================================================
@@ -116,16 +115,16 @@ function ResponsiveFieldInner<T>({
   renderInnerField,
   defaultValue,
 }: ResponsiveFieldProps<T>) {
-  const [activeBreakpoint, setActiveBreakpoint] = useState<Breakpoint>('base')
+  const [activeBreakpoint, setActiveBreakpoint] = useState<Breakpoint>('xs')
 
   // Get the current value for the active breakpoint
-  // Falls back through the cascade: active -> smaller breakpoints -> base -> default
+  // Falls back through the cascade: active -> smaller breakpoints -> xs -> default
   const getCurrentValue = useCallback((): T | null => {
     if (!value) return defaultValue ?? null
 
-    // For base, just return base value
-    if (activeBreakpoint === 'base') {
-      return value.base ?? defaultValue ?? null
+    // For xs, just return xs value
+    if (activeBreakpoint === 'xs') {
+      return value.xs ?? defaultValue ?? null
     }
 
     // For other breakpoints, return explicit override if set
@@ -135,7 +134,7 @@ function ResponsiveFieldInner<T>({
     }
 
     // Otherwise cascade down to find the nearest defined value
-    const breakpointOrder: Breakpoint[] = ['xl', 'lg', 'md', 'sm', 'base']
+    const breakpointOrder: Breakpoint[] = ['xl', 'lg', 'md', 'sm', 'xs']
     const activeIndex = breakpointOrder.indexOf(activeBreakpoint)
 
     for (let i = activeIndex + 1; i < breakpointOrder.length; i++) {
@@ -153,7 +152,7 @@ function ResponsiveFieldInner<T>({
   const hasOverride = useCallback(
     (breakpoint: Breakpoint): boolean => {
       if (!value) return false
-      if (breakpoint === 'base') return value.base !== undefined
+      if (breakpoint === 'xs') return value.xs !== undefined
       return value[breakpoint] !== undefined
     },
     [value]
@@ -162,12 +161,12 @@ function ResponsiveFieldInner<T>({
   // Handle value change for the active breakpoint
   const handleInnerChange = useCallback(
     (newValue: T | null) => {
-      if (activeBreakpoint === 'base') {
-        // Base is required, so we always set it
+      if (activeBreakpoint === 'xs') {
+        // XS is required, so we always set it
         if (newValue === null && defaultValue !== undefined) {
-          onChange({ ...value, base: defaultValue } as ResponsiveValue<T>)
+          onChange({ ...value, xs: defaultValue } as ResponsiveValue<T>)
         } else if (newValue !== null) {
-          onChange({ ...value, base: newValue } as ResponsiveValue<T>)
+          onChange({ ...value, xs: newValue } as ResponsiveValue<T>)
         }
       } else {
         // For other breakpoints, set the override
@@ -177,12 +176,12 @@ function ResponsiveFieldInner<T>({
           delete newResponsive[activeBreakpoint]
           onChange(newResponsive)
         } else {
-          // Ensure base exists
-          const base = value?.base ?? defaultValue
-          if (base === undefined) return
+          // Ensure xs exists
+          const xs = value?.xs ?? defaultValue
+          if (xs === undefined) return
           onChange({
             ...value,
-            base,
+            xs,
             [activeBreakpoint]: newValue,
           } as ResponsiveValue<T>)
         }
@@ -193,7 +192,7 @@ function ResponsiveFieldInner<T>({
 
   // Clear override for current breakpoint
   const handleClearOverride = useCallback(() => {
-    if (activeBreakpoint === 'base' || !value) return
+    if (activeBreakpoint === 'xs' || !value) return
 
     const newResponsive = { ...value }
     delete newResponsive[activeBreakpoint]
@@ -206,10 +205,10 @@ function ResponsiveFieldInner<T>({
   }, [onChange])
 
   const currentValue = getCurrentValue()
-  const isOverrideBreakpoint = activeBreakpoint !== 'base'
+  const isOverrideBreakpoint = activeBreakpoint !== 'xs'
   const currentHasOverride = hasOverride(activeBreakpoint)
 
-  // Count how many breakpoints have overrides (excluding base)
+  // Count how many breakpoints have overrides (excluding xs)
   const overrideCount = value
     ? (['sm', 'md', 'lg', 'xl'] as Breakpoint[]).filter((bp) => value[bp] !== undefined).length
     : 0
@@ -237,7 +236,7 @@ function ResponsiveFieldInner<T>({
             className="text-muted-foreground hover:text-destructive"
             title="Clear all values"
           >
-            <IconX className="h-4 w-4" />
+            <X className="h-4 w-4" />
           </Button>
         )}
       </div>
@@ -261,13 +260,13 @@ function ResponsiveFieldInner<T>({
       {/* Active Breakpoint Info */}
       <div className="flex items-center justify-between text-xs text-muted-foreground">
         <span>
-          {activeBreakpoint === 'base' ? (
-            'Default for all screen sizes'
+          {activeBreakpoint === 'xs' ? (
+            'Extra small screens (0-639px)'
           ) : (
             <>
               {BREAKPOINTS.find((bp) => bp.key === activeBreakpoint)?.minWidth}px and up
               {!currentHasOverride && (
-                <span className="text-muted-foreground/60"> (inheriting from base)</span>
+                <span className="text-muted-foreground/60"> (inheriting from xs)</span>
               )}
             </>
           )}

--- a/src/fields/SizeField.tsx
+++ b/src/fields/SizeField.tsx
@@ -9,7 +9,7 @@
 
 import React, { useCallback, memo } from 'react'
 import type { CustomField } from '@measured/puck'
-import { IconX } from '@tabler/icons-react'
+import { X } from 'lucide-react'
 import { Button } from '../components/ui/button'
 import { Input } from '../components/ui/input'
 import { Label } from '../components/ui/label'
@@ -137,7 +137,7 @@ function SizeFieldInner({
             className="text-muted-foreground hover:text-destructive"
             title="Reset to default"
           >
-            <IconX className="h-4 w-4" />
+            <X className="h-4 w-4" />
           </Button>
         )}
       </div>

--- a/src/fields/TemplateField.tsx
+++ b/src/fields/TemplateField.tsx
@@ -17,15 +17,15 @@ import type { CustomField } from '@measured/puck'
 import { createUsePuck } from '@measured/puck'
 import type { Data } from '@measured/puck'
 import {
-  IconTemplate,
-  IconLoader2,
-  IconDeviceFloppy,
-  IconDownload,
-  IconAlertCircle,
-  IconChevronDown,
-  IconChevronUp,
-  IconX,
-} from '@tabler/icons-react'
+  LayoutTemplate,
+  Loader2,
+  Save,
+  Download,
+  AlertCircle,
+  ChevronDown,
+  ChevronUp,
+  X,
+} from 'lucide-react'
 import { Button } from '../components/ui/button'
 import { Input } from '../components/ui/input'
 import { Label } from '../components/ui/label'
@@ -450,7 +450,7 @@ function TemplateFieldInner({
             title="Clear selection"
             className="text-muted-foreground hover:text-foreground"
           >
-            <IconX className="h-4 w-4" />
+            <X className="h-4 w-4" />
           </Button>
         )}
       </div>
@@ -466,9 +466,9 @@ function TemplateFieldInner({
             disabled={loading || saveForm.saving}
           >
             {saveForm.expanded ? (
-              <IconChevronUp className="h-4 w-4" />
+              <ChevronUp className="h-4 w-4" />
             ) : (
-              <IconDeviceFloppy className="h-4 w-4" />
+              <Save className="h-4 w-4" />
             )}
             {saveForm.expanded ? 'Cancel' : 'Save as Template'}
           </Button>
@@ -482,9 +482,9 @@ function TemplateFieldInner({
               disabled={loadingTemplate}
             >
               {loadingTemplate ? (
-                <IconLoader2 className="h-4 w-4 animate-spin" />
+                <Loader2 className="h-4 w-4 animate-spin" />
               ) : (
-                <IconDownload className="h-4 w-4" />
+                <Download className="h-4 w-4" />
               )}
               Reload
             </Button>
@@ -545,7 +545,7 @@ function TemplateFieldInner({
 
           {saveForm.error && (
             <div className="p-2 bg-destructive/10 border border-destructive/30 rounded-md text-destructive text-xs flex items-start gap-2">
-              <IconAlertCircle className="h-3.5 w-3.5 flex-shrink-0 mt-0.5" />
+              <AlertCircle className="h-3.5 w-3.5 flex-shrink-0 mt-0.5" />
               <span>{saveForm.error}</span>
             </div>
           )}
@@ -558,12 +558,12 @@ function TemplateFieldInner({
           >
             {saveForm.saving ? (
               <>
-                <IconLoader2 className="h-4 w-4 animate-spin" />
+                <Loader2 className="h-4 w-4 animate-spin" />
                 Saving...
               </>
             ) : (
               <>
-                <IconDeviceFloppy className="h-4 w-4" />
+                <Save className="h-4 w-4" />
                 Save Template
               </>
             )}
@@ -574,7 +574,7 @@ function TemplateFieldInner({
       {/* Error Display */}
       {error && (
         <div className="p-2 bg-destructive/10 border border-destructive/30 rounded-md text-destructive text-sm flex items-start gap-2">
-          <IconAlertCircle className="h-4 w-4 flex-shrink-0 mt-0.5" />
+          <AlertCircle className="h-4 w-4 flex-shrink-0 mt-0.5" />
           <span>{error}</span>
         </div>
       )}

--- a/src/fields/TiptapField.tsx
+++ b/src/fields/TiptapField.tsx
@@ -27,37 +27,37 @@ import Superscript from '@tiptap/extension-superscript'
 import Subscript from '@tiptap/extension-subscript'
 import { Extension } from '@tiptap/core'
 import {
-  IconBold,
-  IconItalic,
-  IconUnderline,
-  IconStrikethrough,
-  IconHighlight,
-  IconLink,
-  IconList,
-  IconListNumbers,
-  IconAlignLeft,
-  IconAlignCenter,
-  IconAlignRight,
-  IconAlignJustified,
-  IconH1,
-  IconH2,
-  IconH3,
-  IconH4,
-  IconH5,
-  IconH6,
-  IconBlockquote,
-  IconCode,
-  IconClearFormatting,
-  IconPalette,
-  IconTextSize,
-  IconX,
-  IconChevronDown,
-  IconSuperscript,
-  IconSubscript,
-  IconSeparatorHorizontal,
-  IconCornerDownLeft,
-  IconLetterP,
-} from '@tabler/icons-react'
+  Bold,
+  Italic,
+  Underline,
+  Strikethrough,
+  Highlighter,
+  Link,
+  List,
+  ListOrdered,
+  AlignLeft,
+  AlignCenter,
+  AlignRight,
+  AlignJustify,
+  Heading1,
+  Heading2,
+  Heading3,
+  Heading4,
+  Heading5,
+  Heading6,
+  Quote,
+  Code,
+  RemoveFormatting,
+  Palette,
+  ALargeSmall,
+  X,
+  ChevronDown,
+  Superscript as SuperscriptIcon,
+  Subscript as SubscriptIcon,
+  Minus,
+  CornerDownLeft,
+  Pilcrow,
+} from 'lucide-react'
 import { cn } from '../lib/utils'
 import './tiptap-styles.css'
 import './richtext-output.css'
@@ -649,42 +649,42 @@ function TiptapFieldInner({ value, onChange, label, readOnly }: TiptapFieldProps
               isActive={formattingState?.isBold}
               title="Bold"
             >
-              <IconBold className={ICON_SIZE} />
+              <Bold className={ICON_SIZE} />
             </ToolbarButton>
             <ToolbarButton
               onClick={() => editor.chain().focus().toggleItalic().run()}
               isActive={formattingState?.isItalic}
               title="Italic"
             >
-              <IconItalic className={ICON_SIZE} />
+              <Italic className={ICON_SIZE} />
             </ToolbarButton>
             <ToolbarButton
               onClick={() => editor.chain().focus().toggleUnderline().run()}
               isActive={formattingState?.isUnderline}
               title="Underline"
             >
-              <IconUnderline className={ICON_SIZE} />
+              <Underline className={ICON_SIZE} />
             </ToolbarButton>
             <ToolbarButton
               onClick={() => editor.chain().focus().toggleStrike().run()}
               isActive={formattingState?.isStrike}
               title="Strikethrough"
             >
-              <IconStrikethrough className={ICON_SIZE} />
+              <Strikethrough className={ICON_SIZE} />
             </ToolbarButton>
             <ToolbarButton
               onClick={() => editor.chain().focus().toggleSuperscript().run()}
               isActive={formattingState?.isSuperscript}
               title="Superscript"
             >
-              <IconSuperscript className={ICON_SIZE} />
+              <SuperscriptIcon className={ICON_SIZE} />
             </ToolbarButton>
             <ToolbarButton
               onClick={() => editor.chain().focus().toggleSubscript().run()}
               isActive={formattingState?.isSubscript}
               title="Subscript"
             >
-              <IconSubscript className={ICON_SIZE} />
+              <SubscriptIcon className={ICON_SIZE} />
             </ToolbarButton>
 
             <div className={TOOLBAR_DIVIDER} />
@@ -693,14 +693,14 @@ function TiptapFieldInner({ value, onChange, label, readOnly }: TiptapFieldProps
             <ToolbarDropdown
               trigger={
                 <span className="flex items-center gap-0.5">
-                  {formattingState?.isH1 ? <IconH1 className={ICON_SIZE} /> :
-                   formattingState?.isH2 ? <IconH2 className={ICON_SIZE} /> :
-                   formattingState?.isH3 ? <IconH3 className={ICON_SIZE} /> :
-                   formattingState?.isH4 ? <IconH4 className={ICON_SIZE} /> :
-                   formattingState?.isH5 ? <IconH5 className={ICON_SIZE} /> :
-                   formattingState?.isH6 ? <IconH6 className={ICON_SIZE} /> :
-                   <IconLetterP className={ICON_SIZE} />}
-                  <IconChevronDown className="w-3 h-3" />
+                  {formattingState?.isH1 ? <Heading1 className={ICON_SIZE} /> :
+                   formattingState?.isH2 ? <Heading2 className={ICON_SIZE} /> :
+                   formattingState?.isH3 ? <Heading3 className={ICON_SIZE} /> :
+                   formattingState?.isH4 ? <Heading4 className={ICON_SIZE} /> :
+                   formattingState?.isH5 ? <Heading5 className={ICON_SIZE} /> :
+                   formattingState?.isH6 ? <Heading6 className={ICON_SIZE} /> :
+                   <Pilcrow className={ICON_SIZE} />}
+                  <ChevronDown className="w-3 h-3" />
                 </span>
               }
               title="Text Type"
@@ -709,32 +709,32 @@ function TiptapFieldInner({ value, onChange, label, readOnly }: TiptapFieldProps
               {(close) => (
                 <>
                   <DropdownItem onClick={() => { editor.chain().focus().setParagraph().run(); close(); }}>
-                    <IconLetterP className={cn(ICON_SIZE, 'mr-2')} />
+                    <Pilcrow className={cn(ICON_SIZE, 'mr-2')} />
                     Paragraph
                   </DropdownItem>
                   <DropdownSeparator />
                   <DropdownItem onClick={() => { editor.chain().focus().toggleHeading({ level: 1 }).run(); close(); }}>
-                    <IconH1 className={cn(ICON_SIZE, 'mr-2')} />
+                    <Heading1 className={cn(ICON_SIZE, 'mr-2')} />
                     <span className="font-bold text-lg">Heading 1</span>
                   </DropdownItem>
                   <DropdownItem onClick={() => { editor.chain().focus().toggleHeading({ level: 2 }).run(); close(); }}>
-                    <IconH2 className={cn(ICON_SIZE, 'mr-2')} />
+                    <Heading2 className={cn(ICON_SIZE, 'mr-2')} />
                     <span className="font-bold text-base">Heading 2</span>
                   </DropdownItem>
                   <DropdownItem onClick={() => { editor.chain().focus().toggleHeading({ level: 3 }).run(); close(); }}>
-                    <IconH3 className={cn(ICON_SIZE, 'mr-2')} />
+                    <Heading3 className={cn(ICON_SIZE, 'mr-2')} />
                     <span className="font-semibold">Heading 3</span>
                   </DropdownItem>
                   <DropdownItem onClick={() => { editor.chain().focus().toggleHeading({ level: 4 }).run(); close(); }}>
-                    <IconH4 className={cn(ICON_SIZE, 'mr-2')} />
+                    <Heading4 className={cn(ICON_SIZE, 'mr-2')} />
                     <span className="font-semibold text-sm">Heading 4</span>
                   </DropdownItem>
                   <DropdownItem onClick={() => { editor.chain().focus().toggleHeading({ level: 5 }).run(); close(); }}>
-                    <IconH5 className={cn(ICON_SIZE, 'mr-2')} />
+                    <Heading5 className={cn(ICON_SIZE, 'mr-2')} />
                     <span className="font-semibold text-xs">Heading 5</span>
                   </DropdownItem>
                   <DropdownItem onClick={() => { editor.chain().focus().toggleHeading({ level: 6 }).run(); close(); }}>
-                    <IconH6 className={cn(ICON_SIZE, 'mr-2')} />
+                    <Heading6 className={cn(ICON_SIZE, 'mr-2')} />
                     <span className="font-semibold text-xs text-gray-600">Heading 6</span>
                   </DropdownItem>
                 </>
@@ -745,7 +745,7 @@ function TiptapFieldInner({ value, onChange, label, readOnly }: TiptapFieldProps
 
             {/* Font Size */}
             <ToolbarDropdown
-              trigger={<IconTextSize className={ICON_SIZE} />}
+              trigger={<ALargeSmall className={ICON_SIZE} />}
               title="Font Size"
             >
               {(close) => (
@@ -832,21 +832,21 @@ function TiptapFieldInner({ value, onChange, label, readOnly }: TiptapFieldProps
               isActive={formattingState?.isBulletList}
               title="Bullet List"
             >
-              <IconList className={ICON_SIZE} />
+              <List className={ICON_SIZE} />
             </ToolbarButton>
             <ToolbarButton
               onClick={() => editor.chain().focus().toggleOrderedList().run()}
               isActive={formattingState?.isOrderedList}
               title="Numbered List"
             >
-              <IconListNumbers className={ICON_SIZE} />
+              <ListOrdered className={ICON_SIZE} />
             </ToolbarButton>
             <ToolbarButton
               onClick={() => editor.chain().focus().toggleBlockquote().run()}
               isActive={formattingState?.isBlockquote}
               title="Blockquote"
             >
-              <IconBlockquote className={ICON_SIZE} />
+              <Quote className={ICON_SIZE} />
             </ToolbarButton>
 
             <div className={TOOLBAR_DIVIDER} />
@@ -857,28 +857,28 @@ function TiptapFieldInner({ value, onChange, label, readOnly }: TiptapFieldProps
               isActive={formattingState?.isAlignLeft}
               title="Align Left"
             >
-              <IconAlignLeft className={ICON_SIZE} />
+              <AlignLeft className={ICON_SIZE} />
             </ToolbarButton>
             <ToolbarButton
               onClick={() => editor.chain().focus().setTextAlign('center').run()}
               isActive={formattingState?.isAlignCenter}
               title="Align Center"
             >
-              <IconAlignCenter className={ICON_SIZE} />
+              <AlignCenter className={ICON_SIZE} />
             </ToolbarButton>
             <ToolbarButton
               onClick={() => editor.chain().focus().setTextAlign('right').run()}
               isActive={formattingState?.isAlignRight}
               title="Align Right"
             >
-              <IconAlignRight className={ICON_SIZE} />
+              <AlignRight className={ICON_SIZE} />
             </ToolbarButton>
             <ToolbarButton
               onClick={() => editor.chain().focus().setTextAlign('justify').run()}
               isActive={formattingState?.isAlignJustify}
               title="Justify"
             >
-              <IconAlignJustified className={ICON_SIZE} />
+              <AlignJustify className={ICON_SIZE} />
             </ToolbarButton>
 
             <div className={TOOLBAR_DIVIDER} />
@@ -890,7 +890,7 @@ function TiptapFieldInner({ value, onChange, label, readOnly }: TiptapFieldProps
                 isActive={formattingState?.isLink}
                 title="Add Link"
               >
-                <IconLink className={ICON_SIZE} />
+                <Link className={ICON_SIZE} />
               </ToolbarButton>
               <LinkPopover
                 isOpen={isLinkPopoverOpen}
@@ -902,7 +902,7 @@ function TiptapFieldInner({ value, onChange, label, readOnly }: TiptapFieldProps
 
             {/* Text Color */}
             <ToolbarDropdown
-              trigger={<IconPalette className={ICON_SIZE} />}
+              trigger={<Palette className={ICON_SIZE} />}
               title="Text Color"
             >
               {(close) => (
@@ -961,7 +961,7 @@ function TiptapFieldInner({ value, onChange, label, readOnly }: TiptapFieldProps
 
             {/* Highlight (background color) */}
             <ToolbarDropdown
-              trigger={<IconHighlight className={ICON_SIZE} />}
+              trigger={<Highlighter className={ICON_SIZE} />}
               title="Highlight"
               isActive={formattingState?.isHighlight}
             >
@@ -993,13 +993,13 @@ function TiptapFieldInner({ value, onChange, label, readOnly }: TiptapFieldProps
               onClick={() => editor.chain().focus().setHorizontalRule().run()}
               title="Horizontal Rule"
             >
-              <IconSeparatorHorizontal className={ICON_SIZE} />
+              <Minus className={ICON_SIZE} />
             </ToolbarButton>
             <ToolbarButton
               onClick={() => editor.chain().focus().setHardBreak().run()}
               title="Hard Break (Shift+Enter)"
             >
-              <IconCornerDownLeft className={ICON_SIZE} />
+              <CornerDownLeft className={ICON_SIZE} />
             </ToolbarButton>
 
             <div className={TOOLBAR_DIVIDER} />
@@ -1009,7 +1009,7 @@ function TiptapFieldInner({ value, onChange, label, readOnly }: TiptapFieldProps
               onClick={() => editor.chain().focus().unsetAllMarks().clearNodes().run()}
               title="Clear Formatting"
             >
-              <IconClearFormatting className={ICON_SIZE} />
+              <RemoveFormatting className={ICON_SIZE} />
             </ToolbarButton>
 
             {/* View Source */}
@@ -1031,7 +1031,7 @@ function TiptapFieldInner({ value, onChange, label, readOnly }: TiptapFieldProps
                 !showSource && 'bg-transparent'
               )}
             >
-              <IconCode className={ICON_SIZE} />
+              <Code className={ICON_SIZE} />
               Source
             </button>
           </div>

--- a/src/fields/TiptapModal.tsx
+++ b/src/fields/TiptapModal.tsx
@@ -9,7 +9,7 @@
 
 import React, { useState, useEffect, useCallback } from 'react'
 import { TiptapField } from './TiptapField'
-import { IconX } from '@tabler/icons-react'
+import { X } from 'lucide-react'
 
 interface TiptapModalProps {
   isOpen: boolean
@@ -119,7 +119,7 @@ export function TiptapModal({ isOpen, onClose, value, onChange, title }: TiptapM
             }}
             title="Close (Esc)"
           >
-            <IconX size={20} />
+            <X size={20} />
           </button>
         </div>
 

--- a/src/fields/TiptapModalField.tsx
+++ b/src/fields/TiptapModalField.tsx
@@ -11,7 +11,7 @@ import React, { useState, memo } from 'react'
 import type { CustomField } from '@measured/puck'
 import { TiptapField } from './TiptapField'
 import { TiptapModal } from './TiptapModal'
-import { IconArrowsMaximize } from '@tabler/icons-react'
+import { Maximize2 } from 'lucide-react'
 
 interface TiptapModalFieldProps {
   value: string
@@ -70,7 +70,7 @@ function TiptapModalFieldInner({ value, onChange, label }: TiptapModalFieldProps
           }}
           title="Open full-screen editor"
         >
-          <IconArrowsMaximize size={14} />
+          <Maximize2 size={14} />
           Expand
         </button>
       </div>

--- a/src/fields/TransformField.tsx
+++ b/src/fields/TransformField.tsx
@@ -16,15 +16,15 @@
 import React, { useCallback, memo, useState } from 'react'
 import type { CustomField } from '@measured/puck'
 import {
-  IconLink,
-  IconLinkOff,
-  IconRotate,
-  IconResize,
-  IconX,
-  IconChevronDown,
-  IconChevronRight,
-  Icon3dCubeSphere,
-} from '@tabler/icons-react'
+  Link,
+  Unlink,
+  RotateCw,
+  Maximize2,
+  X,
+  ChevronDown,
+  ChevronRight,
+  Box,
+} from 'lucide-react'
 import type { TransformValue, TransformOrigin } from './shared'
 import { DEFAULT_TRANSFORM, transformValueToCSS } from './shared'
 import { Button } from '../components/ui/button'
@@ -261,7 +261,7 @@ function TransformFieldInner({
             className="text-muted-foreground hover:text-destructive"
             title="Reset transform"
           >
-            <IconX className="h-4 w-4" />
+            <X className="h-4 w-4" />
           </Button>
         )}
       </div>
@@ -279,7 +279,7 @@ function TransformFieldInner({
       {/* Rotate */}
       <div className="space-y-2 p-3 bg-muted/30 rounded-md">
         <div className="flex items-center gap-2 mb-2">
-          <IconRotate className="h-4 w-4 text-muted-foreground" />
+          <RotateCw className="h-4 w-4 text-muted-foreground" />
           <Label className="text-xs font-medium">Rotate</Label>
         </div>
         <SliderInput
@@ -296,7 +296,7 @@ function TransformFieldInner({
       <div className="space-y-3 p-3 bg-muted/30 rounded-md">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <IconResize className="h-4 w-4 text-muted-foreground" />
+            <Maximize2 className="h-4 w-4 text-muted-foreground" />
             <Label className="text-xs font-medium">Scale</Label>
           </div>
           {!readOnly && (
@@ -313,9 +313,9 @@ function TransformFieldInner({
               }
             >
               {currentValue.scaleLocked ? (
-                <IconLink className="h-3 w-3" />
+                <Link className="h-3 w-3" />
               ) : (
-                <IconLinkOff className="h-3 w-3" />
+                <Unlink className="h-3 w-3" />
               )}
             </Button>
           )}
@@ -444,13 +444,13 @@ function TransformFieldInner({
           className="w-full flex items-center justify-between p-3 bg-muted/30 hover:bg-muted/50 transition-colors"
         >
           <div className="flex items-center gap-2">
-            <Icon3dCubeSphere className="h-4 w-4 text-muted-foreground" />
+            <Box className="h-4 w-4 text-muted-foreground" />
             <Label className="text-xs font-medium cursor-pointer">3D Transforms</Label>
           </div>
           {show3D ? (
-            <IconChevronDown className="h-4 w-4 text-muted-foreground" />
+            <ChevronDown className="h-4 w-4 text-muted-foreground" />
           ) : (
-            <IconChevronRight className="h-4 w-4 text-muted-foreground" />
+            <ChevronRight className="h-4 w-4 text-muted-foreground" />
           )}
         </button>
 

--- a/src/fields/VerticalAlignmentField.tsx
+++ b/src/fields/VerticalAlignmentField.tsx
@@ -10,11 +10,11 @@
 import React, { useCallback, memo } from 'react'
 import type { CustomField } from '@measured/puck'
 import {
-  IconLayoutAlignTop,
-  IconLayoutAlignMiddle,
-  IconLayoutAlignBottom,
-  IconX,
-} from '@tabler/icons-react'
+  AlignStartVertical,
+  AlignCenterVertical,
+  AlignEndVertical,
+  X,
+} from 'lucide-react'
 import { Button } from '../components/ui/button'
 import { Label } from '../components/ui/label'
 import { cn } from '../lib/utils'
@@ -55,9 +55,9 @@ function VerticalAlignmentFieldInner({
   }, [onChange])
 
   const options = [
-    { value: 'flex-start' as VerticalAlignment, icon: IconLayoutAlignTop, title: 'Top' },
-    { value: 'center' as VerticalAlignment, icon: IconLayoutAlignMiddle, title: 'Center' },
-    { value: 'flex-end' as VerticalAlignment, icon: IconLayoutAlignBottom, title: 'Bottom' },
+    { value: 'flex-start' as VerticalAlignment, icon: AlignStartVertical, title: 'Top' },
+    { value: 'center' as VerticalAlignment, icon: AlignCenterVertical, title: 'Center' },
+    { value: 'flex-end' as VerticalAlignment, icon: AlignEndVertical, title: 'Bottom' },
   ]
 
   return (
@@ -75,7 +75,7 @@ function VerticalAlignmentFieldInner({
             className="text-muted-foreground hover:text-destructive"
             title="Reset to default"
           >
-            <IconX className="h-4 w-4" />
+            <X className="h-4 w-4" />
           </Button>
         )}
       </div>

--- a/src/fields/WidthField.tsx
+++ b/src/fields/WidthField.tsx
@@ -13,14 +13,14 @@
 import React, { useCallback, memo } from 'react'
 import type { CustomField } from '@measured/puck'
 import {
-  IconX,
-  IconLayoutAlignLeft,
-  IconLayoutAlignCenter,
-  IconLayoutAlignRight,
-  IconArrowsHorizontal,
-  IconContainer,
-  IconAdjustments,
-} from '@tabler/icons-react'
+  X,
+  AlignLeft,
+  AlignCenter,
+  AlignRight,
+  MoveHorizontal,
+  Container,
+  SlidersHorizontal,
+} from 'lucide-react'
 import type { WidthValue } from './shared'
 import { Button } from '../components/ui/button'
 import { Input } from '../components/ui/input'
@@ -157,7 +157,7 @@ function WidthFieldInner({
             className="text-muted-foreground hover:text-destructive"
             title="Reset to default"
           >
-            <IconX className="h-4 w-4" />
+            <X className="h-4 w-4" />
           </Button>
         )}
       </div>
@@ -165,9 +165,9 @@ function WidthFieldInner({
       {/* Width Mode Selector - segmented control */}
       <div className="flex flex-wrap gap-1">
         {([
-          { mode: 'full' as WidthMode, icon: IconArrowsHorizontal, title: 'Full width (100%)' },
-          { mode: 'contained' as WidthMode, icon: IconContainer, title: 'Contained (centered with max-width)' },
-          { mode: 'custom' as WidthMode, icon: IconAdjustments, title: 'Custom width settings' },
+          { mode: 'full' as WidthMode, icon: MoveHorizontal, title: 'Full width (100%)' },
+          { mode: 'contained' as WidthMode, icon: Container, title: 'Contained (centered with max-width)' },
+          { mode: 'custom' as WidthMode, icon: SlidersHorizontal, title: 'Custom width settings' },
         ]).map(({ mode, icon: Icon, title }) => {
           const isActive = currentValue.mode === mode
           return (
@@ -265,9 +265,9 @@ function WidthFieldInner({
           <Label className="text-xs text-muted-foreground flex-shrink-0">Align:</Label>
           <div className="flex gap-1">
             {([
-              { alignment: 'left' as ContentAlignment, icon: IconLayoutAlignLeft, title: 'Align left' },
-              { alignment: 'center' as ContentAlignment, icon: IconLayoutAlignCenter, title: 'Align center' },
-              { alignment: 'right' as ContentAlignment, icon: IconLayoutAlignRight, title: 'Align right' },
+              { alignment: 'left' as ContentAlignment, icon: AlignLeft, title: 'Align left' },
+              { alignment: 'center' as ContentAlignment, icon: AlignCenter, title: 'Align center' },
+              { alignment: 'right' as ContentAlignment, icon: AlignRight, title: 'Align right' },
             ]).map(({ alignment, icon: Icon, title }) => {
               const isActive = currentValue.alignment === alignment
               const isDisabled = readOnly || currentValue.mode === 'full'

--- a/src/hooks/useResponsiveStyles.ts
+++ b/src/hooks/useResponsiveStyles.ts
@@ -30,7 +30,7 @@ export interface UseResponsiveStylesOptions {
  * Gets the current breakpoint based on window width
  */
 function getCurrentBreakpoint(): Breakpoint {
-  if (typeof window === 'undefined') return 'base'
+  if (typeof window === 'undefined') return 'xs'
 
   const width = window.innerWidth
 
@@ -42,7 +42,7 @@ function getCurrentBreakpoint(): Breakpoint {
     }
   }
 
-  return 'base'
+  return 'xs'
 }
 
 /**
@@ -52,9 +52,9 @@ function getValueForBreakpoint<T>(
   value: ResponsiveValue<T>,
   breakpoint: Breakpoint
 ): T {
-  // For base, return base value directly
-  if (breakpoint === 'base') {
-    return value.base
+  // For xs, return xs value directly
+  if (breakpoint === 'xs') {
+    return value.xs
   }
 
   // Check if this breakpoint has an explicit value
@@ -64,7 +64,7 @@ function getValueForBreakpoint<T>(
   }
 
   // Cascade down to find the nearest defined value
-  const breakpointOrder: Breakpoint[] = ['xl', 'lg', 'md', 'sm', 'base']
+  const breakpointOrder: Breakpoint[] = ['xl', 'lg', 'md', 'sm', 'xs']
   const currentIndex = breakpointOrder.indexOf(breakpoint)
 
   for (let i = currentIndex + 1; i < breakpointOrder.length; i++) {
@@ -75,8 +75,8 @@ function getValueForBreakpoint<T>(
     }
   }
 
-  // Fallback to base
-  return value.base
+  // Fallback to xs
+  return value.xs
 }
 
 // =============================================================================

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -3,23 +3,15 @@ import { writeFileSync, readFileSync } from 'fs'
 import { glob } from 'glob'
 
 // External dependencies (not bundled)
+// Only externalize framework/singleton deps - everything else gets bundled
 const externalDeps = [
   'react',
+  'react-dom',
   'next',
   'next/navigation',
   'payload',
   '@payloadcms/ui',
   '@measured/puck',
-  '@measured/puck-plugin-heading-analyzer',
-  '@tiptap/core',
-  '@tiptap/react',
-  '@tiptap/starter-kit',
-  '@tiptap/extension-underline',
-  '@tiptap/extension-link',
-  '@tiptap/extension-text-align',
-  '@tiptap/extension-text-style',
-  '@tiptap/extension-color',
-  '@tiptap/extension-highlight',
   '@payload-config',
 ]
 


### PR DESCRIPTION
Description:
  - Replace cascade-based visibility with independent per-breakpoint toggles
  - Rename 'base' breakpoint to 'xs' for clarity (Bootstrap convention)
  - Migrate from @tabler/icons-react to lucide-react
  - Fix visibility override counter not resetting properly
  - Update Next.js peer dependency to >=15.4.8
  - Bundle UI dependencies (Radix, lucide, tiptap) instead of externalizing
  - Update README