### PR TITLE
feat: locale awareness

### DIFF
--- a/src/api/createPuckApiRoutesVersions.ts
+++ b/src/api/createPuckApiRoutesVersions.ts
@@ -5,6 +5,7 @@ import type {
   PuckApiVersionsRouteHandlers,
   RouteHandlerWithIdContext,
 } from './types.js'
+import {resolveLocaleFromNextRequest} from "../utils/locale";
 
 /**
  * Create API route handlers for /api/puck/pages/[id]/versions
@@ -89,6 +90,9 @@ export function createPuckApiRoutesVersions(
       const url = new URL(request.url)
       const limit = parseInt(url.searchParams.get('limit') || '20', 10)
       const page = parseInt(url.searchParams.get('page') || '1', 10)
+      const body = await request.json?.()
+      const { _locale } = body || {}
+      const locale = resolveLocaleFromNextRequest(request, _locale)
 
       // Fetch versions for this page
       const versions = await payload.findVersions({
@@ -99,6 +103,7 @@ export function createPuckApiRoutesVersions(
         sort: '-updatedAt',
         limit,
         page,
+        ...(locale ? { locale: locale.toString() } : {}),
       })
 
       return NextResponse.json({

--- a/src/editor/PuckEditorImpl.client.tsx
+++ b/src/editor/PuckEditorImpl.client.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { useState, useCallback, useMemo, useRef, type ReactNode, createElement } from 'react'
+import {useState, useCallback, useMemo, useRef, type ReactNode, createElement, useEffect} from 'react'
 import { useRouter } from 'next/navigation'
 import { Puck, type Config as PuckConfig, type Data, type Plugin as PuckPlugin, type Overrides as PuckOverrides } from '@puckeditor/core'
+import { useLocale } from "@payloadcms/ui";
 import '@puckeditor/core/puck.css'
 import headingAnalyzer from '@puckeditor/plugin-heading-analyzer'
 import '@puckeditor/plugin-heading-analyzer/dist/index.css'
@@ -306,6 +307,17 @@ export function PuckEditorImpl({
   const [wasPublished, setWasPublished] = useState(initialStatus === 'published')
   const { hasUnsavedChanges, markClean, markDirty } = useUnsavedChanges()
 
+  // Get current locale code
+  const { code: currentLocale } = useLocale();
+  // Store the initial locale on mount
+  const initialLocale = useRef(currentLocale);
+  useEffect(() => {
+    // If the locale changes from what it was at load, force a hard refresh
+    if (initialLocale.current && currentLocale !== initialLocale.current) {
+      window.location.reload();
+    }
+  }, [currentLocale]);
+
   // Preview modal state
   const [isPreviewOpen, setIsPreviewOpen] = useState(false)
 
@@ -360,10 +372,10 @@ export function PuckEditorImpl({
   const makeSaveRequest = useCallback(
     async (
       data: Data,
-      options: { publish?: boolean; swapHomepage?: boolean } = {}
+      options: { publish?: boolean; swapHomepage?: boolean, currentLocale?: string } = {}
     ): Promise<Response> => {
       const typedData = data as PuckDataWithMeta
-      return fetch(`${apiEndpoint}/${pageId}`, {
+      return fetch(`${apiEndpoint}/${pageId}${currentLocale ? `?locale=${currentLocale}` : ''}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -379,7 +391,7 @@ export function PuckEditorImpl({
         }),
       })
     },
-    [apiEndpoint, pageId, pageTitle, pageSlug]
+    [apiEndpoint, pageId, pageTitle, pageSlug, currentLocale]
   )
 
   // Handle homepage conflict - prompt user to swap
@@ -397,14 +409,14 @@ export function PuckEditorImpl({
       }
 
       // Retry with swapHomepage flag
-      const response = await makeSaveRequest(data, { publish, swapHomepage: true })
+      const response = await makeSaveRequest(data, { publish, swapHomepage: true, currentLocale })
       if (!response.ok) {
         const errorData = await response.json()
         throw new Error(errorData.error || errorData.message || 'Failed to swap homepage')
       }
       return true
     },
-    [makeSaveRequest]
+    [makeSaveRequest, currentLocale]
   )
 
   // Handle save (as draft)
@@ -413,7 +425,7 @@ export function PuckEditorImpl({
       setIsSaving(true)
       const typedData = data as PuckDataWithMeta
       try {
-        const response = await makeSaveRequest(data, { publish: false })
+        const response = await makeSaveRequest(data, { publish: false, currentLocale})
 
         if (!response.ok) {
           const errorData = await response.json()
@@ -454,7 +466,7 @@ export function PuckEditorImpl({
         setIsSaving(false)
       }
     },
-    [makeSaveRequest, handleHomepageConflict, markClean, onSaveSuccess, onSaveError]
+    [makeSaveRequest, handleHomepageConflict, markClean, onSaveSuccess, onSaveError, currentLocale]
   )
 
   // Handle publish

--- a/src/editor/components/VersionHistory.tsx
+++ b/src/editor/components/VersionHistory.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useCallback, useEffect, useRef, memo, type CSSProperties } from 'react'
+import { useLocale } from '@payloadcms/ui';
 import {
   History,
   Loader2,
@@ -242,12 +243,13 @@ export const VersionHistory = memo(function VersionHistory({
   const [isAvailable, setIsAvailable] = useState<boolean | null>(null)
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null)
   const dropdownRef = useRef<HTMLDivElement>(null)
+  const { code: currentLocale } = useLocale();
 
   // Check if versions endpoint is available on mount
   useEffect(() => {
     async function checkAvailability() {
       try {
-        const response = await fetch(`${apiEndpoint}/${pageId}/versions?limit=1`, {
+        const response = await fetch(`${apiEndpoint}/${pageId}/versions?limit=1${currentLocale ? `&locale=${currentLocale}` : ''}`, {
           method: 'GET',
         })
         setIsAvailable(response.status !== 404)
@@ -274,7 +276,7 @@ export const VersionHistory = memo(function VersionHistory({
     setIsLoading(true)
     setError(null)
     try {
-      const response = await fetch(`${apiEndpoint}/${pageId}/versions?limit=20`)
+      const response = await fetch(`${apiEndpoint}/${pageId}/versions?limit=20${currentLocale ? `&locale=${currentLocale}` : ''}`)
       if (!response.ok) {
         throw new Error('Failed to fetch versions')
       }
@@ -304,10 +306,10 @@ export const VersionHistory = memo(function VersionHistory({
 
       setIsRestoring(true)
       try {
-        const response = await fetch(`${apiEndpoint}/${pageId}/versions`, {
+        const response = await fetch(`${apiEndpoint}/${pageId}/restore`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ versionId: version.id }),
+          body: JSON.stringify({ versionId: version.id, locale: currentLocale }),
         })
 
         if (!response.ok) {

--- a/src/editor/plugins/VersionHistoryPanel.tsx
+++ b/src/editor/plugins/VersionHistoryPanel.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useCallback, useEffect, memo, type CSSProperties } from 'react'
 import { createUsePuck, type Data } from '@puckeditor/core'
-import { Loader2, Check, RotateCcw, AlertCircle } from 'lucide-react'
+import { Loader2, Check, RotateCcw, AlertCircle, CaseUpper } from 'lucide-react'
+import { useLocale } from '@payloadcms/ui';
 
 // Create usePuck hook for accessing editor state and dispatch
 const usePuck = createUsePuck()
@@ -231,13 +232,14 @@ export const VersionHistoryPanel = memo(function VersionHistoryPanel({
   const [error, setError] = useState<string | null>(null)
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null)
   const [successMessage, setSuccessMessage] = useState<string | null>(null)
+  const { code: currentLocale } = useLocale()
 
   // Fetch versions on mount
   const fetchVersions = useCallback(async () => {
     setIsLoading(true)
     setError(null)
     try {
-      const url = `${apiEndpoint}/${pageId}/versions?limit=20`
+      const url = `${apiEndpoint}/${pageId}/versions?limit=20${currentLocale ? `&locale=${currentLocale}` : ''}`;
       const response = await fetch(url)
       if (!response.ok) {
         if (response.status === 404) {
@@ -275,10 +277,10 @@ export const VersionHistoryPanel = memo(function VersionHistoryPanel({
 
       try {
         // Call restore endpoint
-        const response = await fetch(`${apiEndpoint}/${pageId}/versions`, {
+        const response = await fetch(`${apiEndpoint}/${pageId}/restore`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ versionId: version.id }),
+          body: JSON.stringify({ versionId: version.id, locale: currentLocale }),
         })
 
         if (!response.ok) {
@@ -312,7 +314,7 @@ export const VersionHistoryPanel = memo(function VersionHistoryPanel({
         setIsRestoring(false)
       }
     },
-    [apiEndpoint, pageId, dispatch, onRestoreSuccess, fetchVersions]
+    [apiEndpoint, pageId, dispatch, onRestoreSuccess, fetchVersions, currentLocale]
   )
 
   // Format date for display

--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -8,6 +8,7 @@
 import type { PayloadHandler, CollectionSlug } from 'payload'
 import { APIError } from 'payload'
 import { unsetHomepage, HomepageConflictError } from '../plugin/hooks/isHomepageUnique.js'
+import { resolveLocale } from '../utils/locale.js'
 
 export interface PuckEndpointOptions {
   collections: string[]
@@ -31,11 +32,16 @@ export function createListHandler(options: PuckEndpointOptions): PayloadHandler 
         )
       }
 
+      const body = await req.json?.()
+      const { _locale, ...data } = body || {}
+      const locale = resolveLocale(req, _locale)
+
       const result = await req.payload.find({
         collection: collection as CollectionSlug,
         draft: true,
         depth: 0,
         limit: 100,
+        ...(locale ? { locale: locale.toString() } : {}),
       })
 
       return Response.json(result)
@@ -68,11 +74,19 @@ export function createCreateHandler(options: PuckEndpointOptions): PayloadHandle
       }
 
       const body = await req.json?.()
+      const { _locale, ...data } = body || {}
+      let locale = resolveLocale(req, _locale)
+      const referrer = req.headers.get('referer');
+      if(referrer && !locale){
+          const { searchParams } = new URL(referrer);
+          locale = searchParams.get('locale') || undefined;
+      }
 
       const doc = await req.payload.create({
         collection: collection as CollectionSlug,
-        data: body,
+        data,
         draft: true,
+        ...(locale ? { locale: locale.toString() } : {}),
       })
 
       return Response.json({ doc })
@@ -104,12 +118,16 @@ export function createGetHandler(options: PuckEndpointOptions): PayloadHandler {
           { status: 400 }
         )
       }
+      const body = await req.json?.()
+      const { _locale, ...data } = body || {}
+      const locale = resolveLocale(req, _locale)
 
       const doc = await req.payload.findByID({
         collection: collection as CollectionSlug,
         id,
         draft: true,
         depth: 0,
+        ...(locale ? { locale: locale.toString() } : {}),
       })
 
       return Response.json({ doc })
@@ -143,7 +161,13 @@ export function createUpdateHandler(options: PuckEndpointOptions): PayloadHandle
       }
 
       const body = await req.json?.()
-      const { _status, swapHomepage, ...data } = body || {}
+      const { _status, _locale, swapHomepage, ...data } = body || {}
+      let locale = resolveLocale(req, _locale);
+      const referrer = req.headers.get('referer');
+      if(referrer && !locale){
+          const { searchParams } = new URL(referrer);
+          locale = searchParams.get('locale') || undefined;
+      }
 
       // Determine if this is a publish or draft save
       const shouldPublish = _status === 'published'
@@ -163,12 +187,13 @@ export function createUpdateHandler(options: PuckEndpointOptions): PayloadHandle
           },
           limit: 1,
           depth: 0,
+          ...(locale ? { locale: locale.toString() } : {}),
         })
 
         // Unset the existing homepage if found
         if (existingHomepage.docs.length > 0) {
           const existingId = String(existingHomepage.docs[0].id)
-          await unsetHomepage(req.payload, collection, existingId)
+          await unsetHomepage(req.payload, collection, existingId, locale)
         }
       }
 
@@ -182,6 +207,7 @@ export function createUpdateHandler(options: PuckEndpointOptions): PayloadHandle
         draft: !shouldPublish,
         // Skip the isHomepage hook if we've already handled the swap
         context: swapHomepage ? { skipIsHomepageHook: true } : undefined,
+        ...(locale ? { locale: locale.toString() } : {}),
       })
 
       return Response.json({ doc, published: shouldPublish })
@@ -202,11 +228,8 @@ export function createUpdateHandler(options: PuckEndpointOptions): PayloadHandle
       // Handle other APIErrors
       if (error instanceof APIError) {
         return Response.json(
-          {
-            error: error.message,
-            data: error.data,
-          },
-          { status: error.status || 500 }
+            { error: error.message, data: error.data },
+            { status: error.status || 500 }
         )
       }
 
@@ -261,6 +284,7 @@ export function createVersionsHandler(options: PuckEndpointOptions): PayloadHand
   const { collections } = options
 
   return async (req) => {
+      const locale = resolveLocale(req)
     try {
       const collection = req.routeParams?.collection as string
       const id = req.routeParams?.id as string
@@ -279,6 +303,7 @@ export function createVersionsHandler(options: PuckEndpointOptions): PayloadHand
         },
         sort: '-updatedAt',
         limit: 20,
+        ...(locale ? { locale: locale.toString(), fallbackLocale: false} : {}),
       })
 
       return Response.json({ versions: versions.docs })
@@ -312,7 +337,7 @@ export function createRestoreHandler(options: PuckEndpointOptions): PayloadHandl
       }
 
       const body = await req.json?.()
-      const { versionId } = body || {}
+      const { versionId, locale } = body || {}
 
       if (!versionId) {
         return Response.json(
@@ -324,6 +349,7 @@ export function createRestoreHandler(options: PuckEndpointOptions): PayloadHandl
       const doc = await req.payload.restoreVersion({
         collection: collection as CollectionSlug,
         id: versionId,
+        ...(locale ? { locale: locale.toString() } : {}),
       })
 
       return Response.json({ doc })

--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -33,7 +33,7 @@ export function createListHandler(options: PuckEndpointOptions): PayloadHandler 
       }
 
       const body = await req.json?.()
-      const { _locale, ...data } = body || {}
+      const { _locale } = body || {}
       const locale = resolveLocale(req, _locale)
 
       const result = await req.payload.find({
@@ -119,7 +119,7 @@ export function createGetHandler(options: PuckEndpointOptions): PayloadHandler {
         )
       }
       const body = await req.json?.()
-      const { _locale, ...data } = body || {}
+      const { _locale } = body || {}
       const locale = resolveLocale(req, _locale)
 
       const doc = await req.payload.findByID({
@@ -205,8 +205,12 @@ export function createUpdateHandler(options: PuckEndpointOptions): PayloadHandle
           _status: shouldPublish ? 'published' : 'draft',
         },
         draft: !shouldPublish,
-        // Skip the isHomepage hook if we've already handled the swap
-        context: swapHomepage ? { skipIsHomepageHook: true } : undefined,
+        context: {
+          // Skip the isHomepage hook if we've already handled the swap
+          ...((swapHomepage || locale) && { skipIsHomepageHook: swapHomepage }),
+          // Pass locale to context so hooks can access it without re-reading body
+          ...(locale && { locale }),
+        },
         ...(locale ? { locale: locale.toString() } : {}),
       })
 

--- a/src/plugin/hooks/isHomepageUnique.ts
+++ b/src/plugin/hooks/isHomepageUnique.ts
@@ -1,5 +1,6 @@
 import type { CollectionBeforeChangeHook } from 'payload'
 import { APIError } from 'payload'
+import { resolveLocale } from '../../utils/locale'
 
 /**
  * Information about an existing homepage page
@@ -81,10 +82,14 @@ export function createIsHomepageUniqueHook(
     }
 
     const collectionSlug = options.collectionSlug || collection.slug
+    const body = await req.json?.()
+    const { _locale } = body || {}
+    const locale = resolveLocale(req, _locale)
 
     // Query for existing homepage (excluding current document)
     const existingHomepage = await req.payload.find({
       collection: collectionSlug,
+      ...(locale ? { locale: locale.toString() } : {}),
       where: {
         and: [
           { isHomepage: { equals: true } },
@@ -121,7 +126,8 @@ export function createIsHomepageUniqueHook(
 export async function unsetHomepage(
   payload: any,
   collectionSlug: string,
-  pageId: string
+  pageId: string,
+  locale?: string
 ): Promise<void> {
   await payload.update({
     collection: collectionSlug,
@@ -133,5 +139,6 @@ export async function unsetHomepage(
     context: {
       skipIsHomepageHook: true,
     },
+    ...(locale ? { locale: locale.toString() } : {}),
   })
 }

--- a/src/plugin/hooks/isHomepageUnique.ts
+++ b/src/plugin/hooks/isHomepageUnique.ts
@@ -1,6 +1,5 @@
 import type { CollectionBeforeChangeHook } from 'payload'
 import { APIError } from 'payload'
-import { resolveLocale } from '../../utils/locale'
 
 /**
  * Information about an existing homepage page
@@ -82,9 +81,8 @@ export function createIsHomepageUniqueHook(
     }
 
     const collectionSlug = options.collectionSlug || collection.slug
-    const body = await req.json?.()
-    const { _locale } = body || {}
-    const locale = resolveLocale(req, _locale)
+    // Use locale from context (passed by endpoint handler) or fall back to req.locale
+    const locale = context?.locale || req.locale
 
     // Query for existing homepage (excluding current document)
     const existingHomepage = await req.payload.find({

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -1,0 +1,37 @@
+/**
+ * Locale Resolver - Determines the locale to use for a Payload operation based on multiple sources.
+*/
+import { Locale, PayloadHandler } from "payload"
+import {NextRequest} from "next/server";
+
+/**
+ * Resolves the locale to use for a Payload operation.
+ *
+ * Priority:
+ *   1. Explicit `_locale` field in the request body (sent by PuckEditor)
+ *   2. `?locale=` query param  (standard REST convention, already parsed by Payload)
+ *   3. `req.locale` set by Payload's middleware (from admin UI context)
+ */
+export function resolveLocale(
+  req: Parameters<PayloadHandler>[0],
+  bodyLocale?: string,
+): string | undefined {
+    if (bodyLocale) return bodyLocale
+    const queryLocale = req.query?.locale as string | undefined
+    if (queryLocale) return queryLocale
+    if (req.locale) return typeof req.locale === 'string' ? req.locale : (req.locale as Locale).code
+    return undefined
+}
+
+/**
+ * Resolves the locale from NextRequest
+*/
+export function resolveLocaleFromNextRequest(
+    req: NextRequest,
+    bodyLocale?: string,
+): string | undefined {
+    if (bodyLocale) return bodyLocale
+    const queryLocale = req.nextUrl.searchParams.get('locale') as string | undefined
+    if (queryLocale) return queryLocale
+    return undefined
+}

--- a/src/views/PuckEditorView.tsx
+++ b/src/views/PuckEditorView.tsx
@@ -88,12 +88,17 @@ export async function PuckEditorView({
   let error: string | null = null
   const needsRelationships = typeof previewUrlConfig === 'function'
 
+  // Read locale from searchParams (e.g. ?locale=bg)
+  const resolvedSearch = await searchParams
+  const locale = (resolvedSearch?.locale as string | undefined) || req.locale
+
   try {
     page = await payload.findByID({
       collection: collection as any,
       id: pageId,
       draft: true, // Always get draft for editing
       depth: needsRelationships ? 1 : 0,
+      locale,
     })
   } catch (err) {
     console.error('[PuckEditorView] Error fetching page:', err)


### PR DESCRIPTION
This commit adds comprehensive locale awareness to the Puck editor, enabling multi-language/multi-region support across the entire system. The changes implement a locale resolution system and propagate locale information throughout all editor operations.
Following the [documentation](https://payloadcms.com/docs/configuration/localization)  of PayloadCMS for the internal localization mechanism.

### Impact
Full locale support for page editing, saving, publishing, and version history
Seamless multi-language content management within the Puck editor
Prevents locale switching confusion with automatic page reload