### PR TITLE
fix: editor shows  on load without any user edit (production builds only)

### DIFF
--- a/src/editor/PuckEditorImpl.client.tsx
+++ b/src/editor/PuckEditorImpl.client.tsx
@@ -17,6 +17,7 @@ import { IframeWrapper, type LayoutStyle } from './components/IframeWrapper.js'
 import { PreviewModal } from './components/PreviewModal.js'
 import { DarkModeStyles } from './components/DarkModeStyles.js'
 import { useUnsavedChanges } from './hooks/useUnsavedChanges.js'
+import { isDataEqual } from './utils/isDataEqual.js'
 import { createVersionHistoryPlugin } from './plugins/versionHistoryPlugin.js'
 import { ThemeProvider, type ThemeConfig } from '../theme/index.js'
 import { usePuckConfig } from '../views/PuckConfigContext.js'
@@ -351,6 +352,12 @@ export function PuckEditorImpl({
   // Use a ref to track latest data without causing re-renders
   const latestDataRef = useRef<PuckDataWithMeta>(dataWithSlug)
 
+  // Track the last loaded/saved data so we can distinguish real user edits from
+  // no-op onChange dispatches (e.g. Puck's mount-time resolve pass). Refreshed at
+  // every markClean() site (save / publish) so subsequent edits diff against the
+  // most recently persisted state.
+  const savedDataRef = useRef<PuckDataWithMeta>(dataWithSlug)
+
   // Get editor stylesheets from PuckConfigProvider context (as fallback)
   const { editorStylesheets: contextStylesheets, editorCss: contextCss } = usePuckConfig()
 
@@ -465,6 +472,7 @@ export function PuckEditorImpl({
         setSaveError(null) // Clear any previous error
         // After saving as draft, update status to draft (shows "Unpublished Changes" if was published)
         setDocumentStatus('draft')
+        savedDataRef.current = typedData
         markClean()
         onSaveSuccess?.(data)
       } catch (error) {
@@ -515,6 +523,7 @@ export function PuckEditorImpl({
         setSaveError(null) // Clear any previous error
         setDocumentStatus('published') // Update status after successful publish
         setWasPublished(true) // Mark as having been published
+        savedDataRef.current = typedData
         markClean()
         onSaveSuccess?.(data)
       } catch (error) {
@@ -568,10 +577,19 @@ export function PuckEditorImpl({
   const handleChange = useCallback(
     (data: Data) => {
       latestDataRef.current = data as PuckDataWithMeta
-      markDirty()
+      // Only mark dirty when the data actually differs from the last loaded/saved
+      // state. Puck fires onChange for no-op mount-time resolves (which can differ
+      // from the loaded data only by undefined-valued keys); treating those as
+      // edits produces a spurious "Unsaved" flag on load. isDataEqual is
+      // undefined-tolerant so those resolves compare equal and clear the flag.
+      if (isDataEqual(data, savedDataRef.current)) {
+        markClean()
+      } else {
+        markDirty()
+      }
       onChangeProp?.(data)
     },
-    [markDirty, onChangeProp]
+    [markClean, markDirty, onChangeProp]
   )
 
   // Handle back navigation

--- a/src/editor/utils/index.ts
+++ b/src/editor/utils/index.ts
@@ -1,2 +1,3 @@
 export { injectPageTreeFields } from './injectPageTreeFields.js'
 export { detectPageTree, hasPageTreeFields } from './detectPageTree.js'
+export { isDataEqual } from './isDataEqual.js'

--- a/src/editor/utils/isDataEqual.ts
+++ b/src/editor/utils/isDataEqual.ts
@@ -1,0 +1,60 @@
+/**
+ * Undefined-tolerant deep equality for Puck data.
+ *
+ * Puck's mount-time resolve pass (`resolveAndCommitData`) can dispatch a `replace`
+ * even when the net content is unchanged — e.g. a resolved node differs from the
+ * loaded node only by an `undefined`-valued key. Strict deep-equal libraries such
+ * as `fast-equals` treat `{}` and `{ k: undefined }` as different, so that no-op
+ * resolve looks like a real edit and spuriously marks the document dirty.
+ *
+ * This comparison treats an absent key and an `undefined`-valued key as equal, so
+ * a resolve that only adds/removes `undefined` values compares equal to the loaded
+ * data. Object key order is irrelevant (as with any deep equal); array order is
+ * significant (Puck content order is meaningful).
+ */
+export function isDataEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) {
+    return true
+  }
+
+  // NaN is handled by Object.is above; remaining primitives that differ are unequal.
+  if (typeof a !== 'object' || typeof b !== 'object' || a === null || b === null) {
+    return false
+  }
+
+  const aIsArray = Array.isArray(a)
+  const bIsArray = Array.isArray(b)
+  if (aIsArray !== bIsArray) {
+    return false
+  }
+
+  if (aIsArray && bIsArray) {
+    if (a.length !== b.length) {
+      return false
+    }
+    for (let i = 0; i < a.length; i++) {
+      if (!isDataEqual(a[i], b[i])) {
+        return false
+      }
+    }
+    return true
+  }
+
+  const aObj = a as Record<string, unknown>
+  const bObj = b as Record<string, unknown>
+
+  // Compare the union of keys, treating a missing key and an `undefined` value as
+  // equivalent so that `{}` and `{ k: undefined }` are considered equal.
+  const keys = new Set<string>([...Object.keys(aObj), ...Object.keys(bObj)])
+  for (const key of keys) {
+    const aVal = aObj[key]
+    const bVal = bObj[key]
+    if (aVal === undefined && bVal === undefined) {
+      continue
+    }
+    if (!isDataEqual(aVal, bVal)) {
+      return false
+    }
+  }
+  return true
+}


### PR DESCRIPTION
## What was wrong

`PuckEditorImpl.handleChange` called `markDirty()` unconditionally on every `onChange`. Puck's mount-time resolve pass (`resolveAndCommitData`) fires a no-op `onChange` a few seconds after load whenever a resolved node differs from the loaded node only by cosmetic differences (e.g. an `undefined`-valued key that `fast-equals` counts as a change). That flipped the editor to **"Unsaved"** with no user interaction, in production builds.

## The fix

**`src/editor/utils/isDataEqual.ts`** (new) — an **undefined-tolerant** deep-equal: treats an absent key and an `undefined`-valued key as equal (`{}` ≡ `{k: undefined}`), object-key-order-insensitive, array-order-sensitive. This is what makes the no-op resolve compare equal to the loaded data (plain `fast-equals` would not — that's the root of the bug).

**`src/editor/PuckEditorImpl.client.tsx`**:
- Added `savedDataRef`, seeded from the initial (slug-injected) data.
- `handleChange` now diffs incoming data against `savedDataRef`: equal → `markClean()`, different → `markDirty()`. So the spurious mount resolve clears the flag instead of setting it, and a genuine edit still marks dirty.
- Refreshed `savedDataRef.current` at both `markClean()` sites (`handleSave`, `handlePublish`) so post-save edits diff against the freshly persisted state.